### PR TITLE
Test mctp message header serialization and deserialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,6 +107,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,6 +143,7 @@ dependencies = [
  "espi-device",
  "num_enum",
  "pretty_assertions",
+ "rstest",
  "smbus-pec",
  "thiserror",
  "tokio",
@@ -233,16 +249,93 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+
+[[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "rstest"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afd55a67069d6e434a95161415f5beeada95a01c7b815508a82dcb0e1593682"
+dependencies = [
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4165dfae59a39dd41d8dec720d3cbfbc71f69744efb480a3920f5d4e0cc6798d"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.106",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ thiserror = { version = "2.0.16", default-features = false }
 [dev-dependencies]
 pretty_assertions = "1.4.1"
 tokio = { version = "1.0", features = ["macros", "rt"] }
+rstest = { version = "0.21.0", default-features = false }

--- a/src/message_header/mctp_vendor_defined_pci_message_header.rs
+++ b/src/message_header/mctp_vendor_defined_pci_message_header.rs
@@ -20,6 +20,7 @@ impl From<MctpVendorDefinedPciMessageHeader> for MctpMessageHeader {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
     #[test]
     fn test_mctp_vendor_defined_pci_message_header_bit_register() {
@@ -43,5 +44,24 @@ mod tests {
             TryInto::<u32>::try_into(as_struct).unwrap().to_be_bytes(),
             as_be_bytes
         );
+    }
+
+    #[rstest]
+    #[case(0, MctpMessageType::VendorDefinedPci, 0x0000)]
+    #[case(1, MctpMessageType::VendorDefinedPci, 0xFFFF)]
+    #[case(0, MctpMessageType::VendorDefinedPci, 0x1234)]
+    fn serialize_deserialize_roundtrip(
+        #[case] integrity_check: u8,
+        #[case] message_type: MctpMessageType,
+        #[case] pci_vendor_id: u16,
+    ) {
+        let header = MctpVendorDefinedPciMessageHeader {
+            integrity_check,
+            message_type,
+            pci_vendor_id,
+        };
+        let bytes = TryInto::<u32>::try_into(header).unwrap().to_be_bytes();
+        let parsed = MctpVendorDefinedPciMessageHeader::try_from(u32::from_be_bytes(bytes)).unwrap();
+        assert_eq!(parsed, header);
     }
 }

--- a/src/message_header/mod.rs
+++ b/src/message_header/mod.rs
@@ -16,3 +16,31 @@ bit_register! {
         pub rest: u32 => [0:23],
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mctp_message_type::MctpMessageType;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(0, MctpMessageType::MctpControl, 0)]
+    #[case(1, MctpMessageType::MctpControl, 0)]
+    #[case(0, MctpMessageType::VendorDefinedPci, 0)]
+    #[case(1, MctpMessageType::VendorDefinedPci, 0)]
+    fn serialize_deserialize_mctp_message_header(
+        #[case] integrity_check: u8,
+        #[case] message_type: MctpMessageType,
+        #[case] rest: u32,
+    ) {
+        let header = MctpMessageHeader {
+            integrity_check,
+            message_type,
+            rest,
+        };
+
+        let be_bytes = TryInto::<u32>::try_into(header).unwrap().to_be_bytes();
+        let parsed = MctpMessageHeader::try_from(u32::from_be_bytes(be_bytes)).unwrap();
+        assert_eq!(parsed, header);
+    }
+}


### PR DESCRIPTION
Add rstest-based serialize/deserialize tests for MCTP message headers to improve test coverage.

---
<a href="https://cursor.com/background-agent?bcId=bc-0279ea0c-82dc-4c05-b76b-720f3e790135">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0279ea0c-82dc-4c05-b76b-720f3e790135">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

