### PR TITLE
phase-25: BufferEncoding abstraction + cursor wrappers

### DIFF
--- a/src/buffer_encoding.rs
+++ b/src/buffer_encoding.rs
@@ -96,14 +96,13 @@ impl BufferEncoding for PassthroughEncoding {
 /// copy loop in `MctpPacketContext`) so they cannot accidentally bypass
 /// the encoding by slicing the underlying buffer directly.
 ///
-/// Holds three pieces of state: the borrowed wire buffer, a cursor
-/// (`wire_pos`) into it, and a count of decoded bytes emitted so far.
-/// The cursor advances by the per-call wire-bytes-consumed value
-/// returned by `E::read_byte` (1 for plain, ≥2 for an escape sequence).
+/// Holds two pieces of state: the borrowed wire buffer and a cursor
+/// (`wire_pos`) into it. The cursor advances by the per-call
+/// wire-bytes-consumed value returned by `E::read_byte` (1 for plain,
+/// ≥2 for an escape sequence).
 pub struct EncodingDecoder<'buf, E: BufferEncoding> {
     buf: &'buf [u8],
     wire_pos: usize,
-    decoded_count: usize,
     _phantom: core::marker::PhantomData<E>,
 }
 
@@ -113,7 +112,6 @@ impl<'buf, E: BufferEncoding> EncodingDecoder<'buf, E> {
         Self {
             buf,
             wire_pos: 0,
-            decoded_count: 0,
             _phantom: core::marker::PhantomData,
         }
     }
@@ -125,18 +123,12 @@ impl<'buf, E: BufferEncoding> EncodingDecoder<'buf, E> {
     pub fn read(&mut self) -> Result<u8, DecodeError> {
         let (byte, n) = E::read_byte(&self.buf[self.wire_pos..])?;
         self.wire_pos += n;
-        self.decoded_count += 1;
         Ok(byte)
     }
 
     /// Wire bytes consumed so far.
     pub fn wire_position(&self) -> usize {
         self.wire_pos
-    }
-
-    /// Decoded bytes emitted so far.
-    pub fn decoded_count(&self) -> usize {
-        self.decoded_count
     }
 
     /// Wire bytes remaining in the underlying buffer.
@@ -149,7 +141,6 @@ impl<E: BufferEncoding> core::fmt::Debug for EncodingDecoder<'_, E> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("EncodingDecoder")
             .field("wire_pos", &self.wire_pos)
-            .field("decoded_count", &self.decoded_count)
             .field("buf_len", &self.buf.len())
             .finish_non_exhaustive()
     }
@@ -161,15 +152,11 @@ impl<E: BufferEncoding> core::fmt::Debug for EncodingDecoder<'_, E> {
 /// into the caller's `message_writer` closure so the closure cannot
 /// accidentally bypass the encoding.
 ///
-/// Tracks both `wire_pos` (cursor into the underlying buffer, advances by
-/// the wire-bytes-written value returned by `E::write_byte`) and
-/// `decoded_count` (number of logical payload bytes written so far,
-/// useful for medium headers that record decoded byte counts —
-/// e.g., DSP0253 `byte_count`).
+/// Tracks `wire_pos` (cursor into the underlying buffer, advances by
+/// the wire-bytes-written value returned by `E::write_byte`).
 pub struct EncodingEncoder<'buf, E: BufferEncoding> {
     buf: &'buf mut [u8],
     wire_pos: usize,
-    decoded_count: usize,
     _phantom: core::marker::PhantomData<E>,
 }
 
@@ -179,7 +166,6 @@ impl<'buf, E: BufferEncoding> EncodingEncoder<'buf, E> {
         Self {
             buf,
             wire_pos: 0,
-            decoded_count: 0,
             _phantom: core::marker::PhantomData,
         }
     }
@@ -190,7 +176,6 @@ impl<'buf, E: BufferEncoding> EncodingEncoder<'buf, E> {
     pub fn write(&mut self, byte: u8) -> Result<(), EncodeError> {
         let n = E::write_byte(&mut self.buf[self.wire_pos..], byte)?;
         self.wire_pos += n;
-        self.decoded_count += 1;
         Ok(())
     }
 
@@ -209,11 +194,6 @@ impl<'buf, E: BufferEncoding> EncodingEncoder<'buf, E> {
         self.wire_pos
     }
 
-    /// Decoded (logical) bytes written so far.
-    pub fn decoded_count(&self) -> usize {
-        self.decoded_count
-    }
-
     /// Wire bytes remaining in the underlying buffer.
     pub fn remaining_wire(&self) -> usize {
         self.buf.len() - self.wire_pos
@@ -224,7 +204,6 @@ impl<E: BufferEncoding> core::fmt::Debug for EncodingEncoder<'_, E> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("EncodingEncoder")
             .field("wire_pos", &self.wire_pos)
-            .field("decoded_count", &self.decoded_count)
             .field("buf_len", &self.buf.len())
             .finish_non_exhaustive()
     }
@@ -293,14 +272,12 @@ mod tests {
         let buf = [0xAA, 0xBB, 0xCC, 0xDD];
         let mut decoder = EncodingDecoder::<PassthroughEncoding>::new(&buf);
         assert_eq!(decoder.wire_position(), 0);
-        assert_eq!(decoder.decoded_count(), 0);
         assert_eq!(decoder.remaining_wire(), 4);
         assert_eq!(decoder.read().unwrap(), 0xAA);
         assert_eq!(decoder.read().unwrap(), 0xBB);
         assert_eq!(decoder.read().unwrap(), 0xCC);
         assert_eq!(decoder.read().unwrap(), 0xDD);
         assert_eq!(decoder.wire_position(), 4);
-        assert_eq!(decoder.decoded_count(), 4);
         assert_eq!(decoder.remaining_wire(), 0);
         assert_eq!(decoder.read().unwrap_err(), DecodeError::PrematureEnd);
     }
@@ -311,14 +288,12 @@ mod tests {
         {
             let mut encoder = EncodingEncoder::<PassthroughEncoding>::new(&mut buf);
             assert_eq!(encoder.wire_position(), 0);
-            assert_eq!(encoder.decoded_count(), 0);
             assert_eq!(encoder.remaining_wire(), 4);
             encoder.write(0x11).unwrap();
             encoder.write(0x22).unwrap();
             encoder.write(0x33).unwrap();
             encoder.write(0x44).unwrap();
             assert_eq!(encoder.wire_position(), 4);
-            assert_eq!(encoder.decoded_count(), 4);
             assert_eq!(encoder.remaining_wire(), 0);
             assert_eq!(encoder.write(0x55).unwrap_err(), EncodeError::BufferFull);
         }

--- a/src/buffer_encoding.rs
+++ b/src/buffer_encoding.rs
@@ -89,6 +89,147 @@ impl BufferEncoding for PassthroughEncoding {
     }
 }
 
+/// Stateful cursor wrapper that reads decoded bytes from a wire buffer
+/// through a [`BufferEncoding`]. Constructed by an [`MctpMedium`]'s
+/// [`deserialize`](crate::medium::MctpMedium::deserialize) method and
+/// handed to higher layers (e.g., `parse_transport_header`, the payload
+/// copy loop in `MctpPacketContext`) so they cannot accidentally bypass
+/// the encoding by slicing the underlying buffer directly.
+///
+/// Holds three pieces of state: the borrowed wire buffer, a cursor
+/// (`wire_pos`) into it, and a count of decoded bytes emitted so far.
+/// The cursor advances by the per-call wire-bytes-consumed value
+/// returned by `E::read_byte` (1 for plain, ≥2 for an escape sequence).
+pub struct EncodingDecoder<'buf, E: BufferEncoding> {
+    buf: &'buf [u8],
+    wire_pos: usize,
+    decoded_count: usize,
+    _phantom: core::marker::PhantomData<E>,
+}
+
+impl<'buf, E: BufferEncoding> EncodingDecoder<'buf, E> {
+    /// Wrap a wire-byte buffer for stateful encoding-mediated reads.
+    pub fn new(buf: &'buf [u8]) -> Self {
+        Self {
+            buf,
+            wire_pos: 0,
+            decoded_count: 0,
+            _phantom: core::marker::PhantomData,
+        }
+    }
+
+    /// Read one decoded byte. Advances the wire cursor by the encoding's
+    /// per-byte wire footprint. Returns `DecodeError::PrematureEnd` when
+    /// the wire buffer is exhausted (or ends mid-escape) and
+    /// `DecodeError::InvalidEscape` for malformed escape sequences.
+    pub fn read(&mut self) -> Result<u8, DecodeError> {
+        let (byte, n) = E::read_byte(&self.buf[self.wire_pos..])?;
+        self.wire_pos += n;
+        self.decoded_count += 1;
+        Ok(byte)
+    }
+
+    /// Wire bytes consumed so far.
+    pub fn wire_position(&self) -> usize {
+        self.wire_pos
+    }
+
+    /// Decoded bytes emitted so far.
+    pub fn decoded_count(&self) -> usize {
+        self.decoded_count
+    }
+
+    /// Wire bytes remaining in the underlying buffer.
+    pub fn remaining_wire(&self) -> usize {
+        self.buf.len() - self.wire_pos
+    }
+}
+
+impl<E: BufferEncoding> core::fmt::Debug for EncodingDecoder<'_, E> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("EncodingDecoder")
+            .field("wire_pos", &self.wire_pos)
+            .field("decoded_count", &self.decoded_count)
+            .field("buf_len", &self.buf.len())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Stateful cursor wrapper that writes decoded bytes into a wire buffer
+/// through a [`BufferEncoding`]. Constructed by an [`MctpMedium`]'s
+/// [`serialize`](crate::medium::MctpMedium::serialize) method and passed
+/// into the caller's `message_writer` closure so the closure cannot
+/// accidentally bypass the encoding.
+///
+/// Tracks both `wire_pos` (cursor into the underlying buffer, advances by
+/// the wire-bytes-written value returned by `E::write_byte`) and
+/// `decoded_count` (number of logical payload bytes written so far,
+/// useful for medium headers that record decoded byte counts —
+/// e.g., DSP0253 `byte_count`).
+pub struct EncodingEncoder<'buf, E: BufferEncoding> {
+    buf: &'buf mut [u8],
+    wire_pos: usize,
+    decoded_count: usize,
+    _phantom: core::marker::PhantomData<E>,
+}
+
+impl<'buf, E: BufferEncoding> EncodingEncoder<'buf, E> {
+    /// Wrap a wire-byte buffer for stateful encoding-mediated writes.
+    pub fn new(buf: &'buf mut [u8]) -> Self {
+        Self {
+            buf,
+            wire_pos: 0,
+            decoded_count: 0,
+            _phantom: core::marker::PhantomData,
+        }
+    }
+
+    /// Write one decoded byte. Advances the wire cursor by the encoding's
+    /// per-byte wire footprint. Returns `EncodeError::BufferFull` when
+    /// the underlying wire buffer cannot fit the encoded representation.
+    pub fn write(&mut self, byte: u8) -> Result<(), EncodeError> {
+        let n = E::write_byte(&mut self.buf[self.wire_pos..], byte)?;
+        self.wire_pos += n;
+        self.decoded_count += 1;
+        Ok(())
+    }
+
+    /// Write a contiguous slice of decoded bytes; aborts on the first
+    /// encode error. Equivalent to a `for &b in bytes { self.write(b)? }`
+    /// loop, but more concise at call sites that just splat a byte slice.
+    pub fn write_all(&mut self, bytes: &[u8]) -> Result<(), EncodeError> {
+        for &b in bytes {
+            self.write(b)?;
+        }
+        Ok(())
+    }
+
+    /// Wire bytes written so far (the size of the produced wire frame).
+    pub fn wire_position(&self) -> usize {
+        self.wire_pos
+    }
+
+    /// Decoded (logical) bytes written so far.
+    pub fn decoded_count(&self) -> usize {
+        self.decoded_count
+    }
+
+    /// Wire bytes remaining in the underlying buffer.
+    pub fn remaining_wire(&self) -> usize {
+        self.buf.len() - self.wire_pos
+    }
+}
+
+impl<E: BufferEncoding> core::fmt::Debug for EncodingEncoder<'_, E> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("EncodingEncoder")
+            .field("wire_pos", &self.wire_pos)
+            .field("decoded_count", &self.decoded_count)
+            .field("buf_len", &self.buf.len())
+            .finish_non_exhaustive()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -145,5 +286,42 @@ mod tests {
         }
         assert_eq!(write_pos, 4);
         assert_eq!(decoded, payload);
+    }
+
+    #[test]
+    fn decoder_reads_all_bytes_via_passthrough() {
+        let buf = [0xAA, 0xBB, 0xCC, 0xDD];
+        let mut decoder = EncodingDecoder::<PassthroughEncoding>::new(&buf);
+        assert_eq!(decoder.wire_position(), 0);
+        assert_eq!(decoder.decoded_count(), 0);
+        assert_eq!(decoder.remaining_wire(), 4);
+        assert_eq!(decoder.read().unwrap(), 0xAA);
+        assert_eq!(decoder.read().unwrap(), 0xBB);
+        assert_eq!(decoder.read().unwrap(), 0xCC);
+        assert_eq!(decoder.read().unwrap(), 0xDD);
+        assert_eq!(decoder.wire_position(), 4);
+        assert_eq!(decoder.decoded_count(), 4);
+        assert_eq!(decoder.remaining_wire(), 0);
+        assert_eq!(decoder.read().unwrap_err(), DecodeError::PrematureEnd);
+    }
+
+    #[test]
+    fn encoder_writes_all_bytes_via_passthrough() {
+        let mut buf = [0u8; 4];
+        {
+            let mut encoder = EncodingEncoder::<PassthroughEncoding>::new(&mut buf);
+            assert_eq!(encoder.wire_position(), 0);
+            assert_eq!(encoder.decoded_count(), 0);
+            assert_eq!(encoder.remaining_wire(), 4);
+            encoder.write(0x11).unwrap();
+            encoder.write(0x22).unwrap();
+            encoder.write(0x33).unwrap();
+            encoder.write(0x44).unwrap();
+            assert_eq!(encoder.wire_position(), 4);
+            assert_eq!(encoder.decoded_count(), 4);
+            assert_eq!(encoder.remaining_wire(), 0);
+            assert_eq!(encoder.write(0x55).unwrap_err(), EncodeError::BufferFull);
+        }
+        assert_eq!(buf, [0x11, 0x22, 0x33, 0x44]);
     }
 }

--- a/src/buffer_encoding.rs
+++ b/src/buffer_encoding.rs
@@ -24,6 +24,8 @@
 //! the caller either uses a separate output buffer or pre-shifts the
 //! payload — that choreography is the caller's job, not this trait's.
 
+use core::marker::PhantomData;
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum EncodeError {
@@ -103,7 +105,7 @@ impl BufferEncoding for PassthroughEncoding {
 pub struct EncodingDecoder<'buf, E: BufferEncoding> {
     buf: &'buf [u8],
     wire_pos: usize,
-    _phantom: core::marker::PhantomData<E>,
+    _phantom: PhantomData<E>,
 }
 
 impl<'buf, E: BufferEncoding> EncodingDecoder<'buf, E> {
@@ -112,7 +114,7 @@ impl<'buf, E: BufferEncoding> EncodingDecoder<'buf, E> {
         Self {
             buf,
             wire_pos: 0,
-            _phantom: core::marker::PhantomData,
+            _phantom: PhantomData,
         }
     }
 
@@ -124,25 +126,6 @@ impl<'buf, E: BufferEncoding> EncodingDecoder<'buf, E> {
         let (byte, n) = E::read_byte(&self.buf[self.wire_pos..])?;
         self.wire_pos += n;
         Ok(byte)
-    }
-
-    /// Wire bytes consumed so far.
-    pub fn wire_position(&self) -> usize {
-        self.wire_pos
-    }
-
-    /// Wire bytes remaining in the underlying buffer.
-    pub fn remaining_wire(&self) -> usize {
-        self.buf.len() - self.wire_pos
-    }
-}
-
-impl<E: BufferEncoding> core::fmt::Debug for EncodingDecoder<'_, E> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("EncodingDecoder")
-            .field("wire_pos", &self.wire_pos)
-            .field("buf_len", &self.buf.len())
-            .finish_non_exhaustive()
     }
 }
 
@@ -157,7 +140,7 @@ impl<E: BufferEncoding> core::fmt::Debug for EncodingDecoder<'_, E> {
 pub struct EncodingEncoder<'buf, E: BufferEncoding> {
     buf: &'buf mut [u8],
     wire_pos: usize,
-    _phantom: core::marker::PhantomData<E>,
+    _phantom: PhantomData<E>,
 }
 
 impl<'buf, E: BufferEncoding> EncodingEncoder<'buf, E> {
@@ -166,7 +149,7 @@ impl<'buf, E: BufferEncoding> EncodingEncoder<'buf, E> {
         Self {
             buf,
             wire_pos: 0,
-            _phantom: core::marker::PhantomData,
+            _phantom: PhantomData,
         }
     }
 
@@ -197,15 +180,6 @@ impl<'buf, E: BufferEncoding> EncodingEncoder<'buf, E> {
     /// Wire bytes remaining in the underlying buffer.
     pub fn remaining_wire(&self) -> usize {
         self.buf.len() - self.wire_pos
-    }
-}
-
-impl<E: BufferEncoding> core::fmt::Debug for EncodingEncoder<'_, E> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("EncodingEncoder")
-            .field("wire_pos", &self.wire_pos)
-            .field("buf_len", &self.buf.len())
-            .finish_non_exhaustive()
     }
 }
 
@@ -271,14 +245,10 @@ mod tests {
     fn decoder_reads_all_bytes_via_passthrough() {
         let buf = [0xAA, 0xBB, 0xCC, 0xDD];
         let mut decoder = EncodingDecoder::<PassthroughEncoding>::new(&buf);
-        assert_eq!(decoder.wire_position(), 0);
-        assert_eq!(decoder.remaining_wire(), 4);
         assert_eq!(decoder.read().unwrap(), 0xAA);
         assert_eq!(decoder.read().unwrap(), 0xBB);
         assert_eq!(decoder.read().unwrap(), 0xCC);
         assert_eq!(decoder.read().unwrap(), 0xDD);
-        assert_eq!(decoder.wire_position(), 4);
-        assert_eq!(decoder.remaining_wire(), 0);
         assert_eq!(decoder.read().unwrap_err(), DecodeError::PrematureEnd);
     }
 

--- a/src/buffer_encoding.rs
+++ b/src/buffer_encoding.rs
@@ -1,0 +1,149 @@
+//! Stateless byte-level buffer-encoding transform for MCTP media.
+//!
+//! Most media (SMBus/eSPI) ship MCTP packets verbatim — wire bytes ARE
+//! payload bytes. Some media (DSP0253 serial) need byte-stuffing: an
+//! escape character expands certain payload bytes into 2-byte sequences
+//! on the wire, and decode reverses that transform.
+//!
+//! [`BufferEncoding`] is the byte-stuffing layer ONLY. It is stateless:
+//! [`write_byte`](BufferEncoding::write_byte) and
+//! [`read_byte`](BufferEncoding::read_byte) are associated functions with
+//! no `self` and no struct state. The caller manages all cursors into the
+//! buffer they own.
+//!
+//! Higher-level framing concerns — start/end delimiters, FCS / CRC
+//! computation — are NOT part of this trait. They live on the medium
+//! type itself (e.g., `MctpSerialMedium::decode_frame_in_place` in a
+//! later phase) which can use `BufferEncoding` for the byte-stuffing
+//! step while owning the framing logic separately.
+//!
+//! Single-buffer in-place transformation is the design intent. For
+//! decode, escape sequences shrink (2 wire bytes → 1 payload byte) so a
+//! caller can read with one cursor and write back into the same buffer
+//! with a lagging write cursor. For encode, escape sequences grow, so
+//! the caller either uses a separate output buffer or pre-shifts the
+//! payload — that choreography is the caller's job, not this trait's.
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum EncodeError {
+    /// `wire_buf` did not have room for the encoded bytes (1 for plain,
+    /// up to 2 for an escape sequence). The caller should advance no
+    /// cursors and treat the encode as failed.
+    BufferFull,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum DecodeError {
+    /// `wire_buf` was empty or ended mid-escape-sequence. Indicates the
+    /// caller asked to decode past the end of valid wire data.
+    PrematureEnd,
+    /// An escape byte was followed by a byte not in the medium's
+    /// accept-list (strict-XOR rule per RFC1662 §4.2 / DSP0253 §6.4).
+    /// The caller should reject the entire frame.
+    InvalidEscape,
+}
+
+/// Stateless byte-stuffing transform. Implementors define how a single
+/// logical (payload) byte maps to one or more wire bytes (encode) and
+/// how a wire-byte prefix maps back to a single payload byte (decode).
+///
+/// All methods are associated functions — there is no `self` and no
+/// struct state. Callers own the buffers and the read/write cursors.
+pub trait BufferEncoding {
+    /// Encode one logical payload byte into `wire_buf` starting at
+    /// index 0. Returns the number of wire bytes written (1 for plain,
+    /// 2 for an escape sequence). The caller advances their write
+    /// cursor by the returned count.
+    fn write_byte(wire_buf: &mut [u8], byte: u8) -> Result<usize, EncodeError>;
+
+    /// Decode the next logical payload byte from `wire_buf` starting at
+    /// index 0. Returns `(decoded_byte, wire_bytes_consumed)`. The
+    /// caller advances their read cursor by `wire_bytes_consumed`.
+    fn read_byte(wire_buf: &[u8]) -> Result<(u8, usize), DecodeError>;
+}
+
+/// No-op encoding: wire bytes ARE payload bytes. Used by media that do
+/// not byte-stuff (SMBus/eSPI, test fixtures).
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct PassthroughEncoding;
+
+impl BufferEncoding for PassthroughEncoding {
+    fn write_byte(wire_buf: &mut [u8], byte: u8) -> Result<usize, EncodeError> {
+        match wire_buf.first_mut() {
+            Some(slot) => {
+                *slot = byte;
+                Ok(1)
+            }
+            None => Err(EncodeError::BufferFull),
+        }
+    }
+
+    fn read_byte(wire_buf: &[u8]) -> Result<(u8, usize), DecodeError> {
+        match wire_buf.first() {
+            Some(&byte) => Ok((byte, 1)),
+            None => Err(DecodeError::PrematureEnd),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn passthrough_write_byte_writes_one_byte() {
+        let mut buf = [0u8; 4];
+        let n = PassthroughEncoding::write_byte(&mut buf, 0xAB).unwrap();
+        assert_eq!(n, 1);
+        assert_eq!(buf, [0xAB, 0, 0, 0]);
+    }
+
+    #[test]
+    fn passthrough_write_byte_full_buffer() {
+        let mut buf = [];
+        let err = PassthroughEncoding::write_byte(&mut buf, 0xAB).unwrap_err();
+        assert_eq!(err, EncodeError::BufferFull);
+    }
+
+    #[test]
+    fn passthrough_read_byte_reads_one_byte() {
+        let buf = [0xAB, 0xCD];
+        let (b, n) = PassthroughEncoding::read_byte(&buf).unwrap();
+        assert_eq!(b, 0xAB);
+        assert_eq!(n, 1);
+    }
+
+    #[test]
+    fn passthrough_read_byte_premature_end() {
+        let buf = [];
+        let err = PassthroughEncoding::read_byte(&buf).unwrap_err();
+        assert_eq!(err, DecodeError::PrematureEnd);
+    }
+
+    #[test]
+    fn passthrough_round_trip() {
+        let payload = [0x01, 0x02, 0x03, 0x04];
+        let mut wire = [0u8; 4];
+        let mut wire_pos = 0;
+        for &b in &payload {
+            wire_pos += PassthroughEncoding::write_byte(&mut wire[wire_pos..], b).unwrap();
+        }
+        assert_eq!(wire_pos, 4);
+        assert_eq!(wire, payload);
+
+        let mut decoded = [0u8; 4];
+        let mut read_pos = 0;
+        let mut write_pos = 0;
+        while read_pos < wire_pos {
+            let (b, n) = PassthroughEncoding::read_byte(&wire[read_pos..wire_pos]).unwrap();
+            decoded[write_pos] = b;
+            read_pos += n;
+            write_pos += 1;
+        }
+        assert_eq!(write_pos, 4);
+        assert_eq!(decoded, payload);
+    }
+}

--- a/src/buffer_encoding.rs
+++ b/src/buffer_encoding.rs
@@ -218,30 +218,6 @@ mod tests {
     }
 
     #[test]
-    fn passthrough_round_trip() {
-        let payload = [0x01, 0x02, 0x03, 0x04];
-        let mut wire = [0u8; 4];
-        let mut wire_pos = 0;
-        for &b in &payload {
-            wire_pos += PassthroughEncoding::write_byte(&mut wire[wire_pos..], b).unwrap();
-        }
-        assert_eq!(wire_pos, 4);
-        assert_eq!(wire, payload);
-
-        let mut decoded = [0u8; 4];
-        let mut read_pos = 0;
-        let mut write_pos = 0;
-        while read_pos < wire_pos {
-            let (b, n) = PassthroughEncoding::read_byte(&wire[read_pos..wire_pos]).unwrap();
-            decoded[write_pos] = b;
-            read_pos += n;
-            write_pos += 1;
-        }
-        assert_eq!(write_pos, 4);
-        assert_eq!(decoded, payload);
-    }
-
-    #[test]
     fn decoder_reads_all_bytes_via_passthrough() {
         let buf = [0xAA, 0xBB, 0xCC, 0xDD];
         let mut decoder = EncodingDecoder::<PassthroughEncoding>::new(&buf);

--- a/src/buffer_encoding.rs
+++ b/src/buffer_encoding.rs
@@ -8,21 +8,8 @@
 //! [`BufferEncoding`] is the byte-stuffing layer ONLY. It is stateless:
 //! [`write_byte`](BufferEncoding::write_byte) and
 //! [`read_byte`](BufferEncoding::read_byte) are associated functions with
-//! no `self` and no struct state. The caller manages all cursors into the
-//! buffer they own.
-//!
-//! Higher-level framing concerns — start/end delimiters, FCS / CRC
-//! computation — are NOT part of this trait. They live on the medium
-//! type itself (e.g., `MctpSerialMedium::decode_frame_in_place` in a
-//! later phase) which can use `BufferEncoding` for the byte-stuffing
-//! step while owning the framing logic separately.
-//!
-//! Single-buffer in-place transformation is the design intent. For
-//! decode, escape sequences shrink (2 wire bytes → 1 payload byte) so a
-//! caller can read with one cursor and write back into the same buffer
-//! with a lagging write cursor. For encode, escape sequences grow, so
-//! the caller either uses a separate output buffer or pre-shifts the
-//! payload — that choreography is the caller's job, not this trait's.
+//! no `self` and no struct state. Higher-level framing concerns
+//! (start/end delimiters, FCS / CRC) live on the medium type, not here.
 
 use core::marker::PhantomData;
 
@@ -43,7 +30,8 @@ pub enum DecodeError {
     PrematureEnd,
     /// An escape byte was followed by a byte not in the medium's
     /// accept-list (strict-XOR rule per RFC1662 §4.2 / DSP0253 §6.4).
-    /// The caller should reject the entire frame.
+    /// The caller should reject the entire frame. Currently unreachable;
+    /// produced only by stuffing encodings introduced in a later phase.
     InvalidEscape,
 }
 
@@ -91,17 +79,12 @@ impl BufferEncoding for PassthroughEncoding {
     }
 }
 
-/// Stateful cursor wrapper that reads decoded bytes from a wire buffer
-/// through a [`BufferEncoding`]. Constructed by an [`MctpMedium`]'s
-/// [`deserialize`](crate::medium::MctpMedium::deserialize) method and
-/// handed to higher layers (e.g., `parse_transport_header`, the payload
-/// copy loop in `MctpPacketContext`) so they cannot accidentally bypass
-/// the encoding by slicing the underlying buffer directly.
+/// Stateful cursor over a `&[u8]` wire buffer that reads decoded bytes
+/// through `E: BufferEncoding`. Constructed by [`MctpMedium::deserialize`]
+/// and handed to higher layers so they cannot bypass the encoding by
+/// slicing the underlying buffer directly.
 ///
-/// Holds two pieces of state: the borrowed wire buffer and a cursor
-/// (`wire_pos`) into it. The cursor advances by the per-call
-/// wire-bytes-consumed value returned by `E::read_byte` (1 for plain,
-/// ≥2 for an escape sequence).
+/// [`MctpMedium::deserialize`]: crate::medium::MctpMedium::deserialize
 pub struct EncodingDecoder<'buf, E: BufferEncoding> {
     buf: &'buf [u8],
     wire_pos: usize,
@@ -129,14 +112,12 @@ impl<'buf, E: BufferEncoding> EncodingDecoder<'buf, E> {
     }
 }
 
-/// Stateful cursor wrapper that writes decoded bytes into a wire buffer
-/// through a [`BufferEncoding`]. Constructed by an [`MctpMedium`]'s
-/// [`serialize`](crate::medium::MctpMedium::serialize) method and passed
-/// into the caller's `message_writer` closure so the closure cannot
-/// accidentally bypass the encoding.
+/// Stateful cursor over a `&mut [u8]` wire buffer that writes decoded
+/// bytes through `E: BufferEncoding`. Constructed by
+/// [`MctpMedium::serialize`] and handed to the caller's `message_writer`
+/// closure so the closure cannot bypass the encoding.
 ///
-/// Tracks `wire_pos` (cursor into the underlying buffer, advances by
-/// the wire-bytes-written value returned by `E::write_byte`).
+/// [`MctpMedium::serialize`]: crate::medium::MctpMedium::serialize
 pub struct EncodingEncoder<'buf, E: BufferEncoding> {
     buf: &'buf mut [u8],
     wire_pos: usize,

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -1,23 +1,44 @@
 use crate::{
-    MctpMessageBuffer, MctpPacketError, error::MctpPacketResult,
-    mctp_transport_header::MctpTransportHeader, medium::MctpMedium,
+    MctpMessageBuffer, MctpPacketError,
+    buffer_encoding::{BufferEncoding, DecodeError},
+    error::MctpPacketResult,
+    mctp_transport_header::MctpTransportHeader,
+    medium::MctpMedium,
 };
+
+fn map_decode_error<M: MctpMedium>(err: DecodeError) -> MctpPacketError<M> {
+    match err {
+        DecodeError::PrematureEnd => {
+            MctpPacketError::HeaderParseError("encoding: premature end of buffer")
+        }
+        DecodeError::InvalidEscape => {
+            MctpPacketError::HeaderParseError("encoding: invalid escape sequence")
+        }
+    }
+}
 
 pub(crate) fn parse_transport_header<M: MctpMedium>(
     packet: &[u8],
 ) -> MctpPacketResult<(MctpTransportHeader, &[u8]), M> {
+    // Necessary lower bound for any BufferEncoding: each decoded byte requires
+    // at least one wire byte. Preserves the original pre-encoding error message.
     if packet.len() < 4 {
         return Err(MctpPacketError::HeaderParseError(
             "Packet is too small, cannot parse transport header",
         ));
     }
-    let transport_header_value = u32::from_be_bytes(packet[0..4].try_into().map_err(|_| {
-        MctpPacketError::HeaderParseError("Packet is too small, cannot parse transport header")
-    })?);
+    let mut header_bytes = [0u8; 4];
+    let mut wire_cursor = 0;
+    for slot in header_bytes.iter_mut() {
+        let (byte, n) = <M::Encoding as BufferEncoding>::read_byte(&packet[wire_cursor..])
+            .map_err(map_decode_error::<M>)?;
+        *slot = byte;
+        wire_cursor += n;
+    }
+    let transport_header_value = u32::from_be_bytes(header_bytes);
     let transport_header = MctpTransportHeader::try_from(transport_header_value)
         .map_err(|_| MctpPacketError::HeaderParseError("Invalid transport header"))?;
-    let packet = &packet[4..];
-    Ok((transport_header, packet))
+    Ok((transport_header, &packet[wire_cursor..]))
 }
 
 pub(crate) fn parse_message_body<M: MctpMedium>(

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -6,32 +6,27 @@ use crate::{
     medium::MctpMedium,
 };
 
-fn map_decode_error<M: MctpMedium>(err: DecodeError) -> MctpPacketError<M> {
-    match err {
-        DecodeError::PrematureEnd => {
-            MctpPacketError::HeaderParseError("encoding: premature end of buffer")
-        }
-        DecodeError::InvalidEscape => {
-            MctpPacketError::HeaderParseError("encoding: invalid escape sequence")
-        }
-    }
-}
-
 pub(crate) fn parse_transport_header<M: MctpMedium>(
     packet: &[u8],
 ) -> MctpPacketResult<(MctpTransportHeader, &[u8]), M> {
-    // Necessary lower bound for any BufferEncoding: each decoded byte requires
-    // at least one wire byte. Preserves the original pre-encoding error message.
-    if packet.len() < 4 {
-        return Err(MctpPacketError::HeaderParseError(
-            "Packet is too small, cannot parse transport header",
-        ));
-    }
+    // Walk 4 decoded bytes through the medium's BufferEncoding. We do NOT
+    // pre-check `packet.len() < 4` because for stuffing encodings that's
+    // misleading: wire length is not decoded length. PrematureEnd from
+    // read_byte is the canonical "ran out of bytes while decoding the header"
+    // signal — it correctly handles BOTH the Passthrough case (wire < 4) AND
+    // the stuffing case (wire >= 4 but yields < 4 decoded bytes).
     let mut header_bytes = [0u8; 4];
     let mut wire_cursor = 0;
     for slot in header_bytes.iter_mut() {
         let (byte, n) = <M::Encoding as BufferEncoding>::read_byte(&packet[wire_cursor..])
-            .map_err(map_decode_error::<M>)?;
+            .map_err(|e| match e {
+                DecodeError::PrematureEnd => MctpPacketError::HeaderParseError(
+                    "Packet is too small, cannot parse transport header",
+                ),
+                DecodeError::InvalidEscape => MctpPacketError::HeaderParseError(
+                    "Invalid encoding escape sequence in transport header",
+                ),
+            })?;
         *slot = byte;
         wire_cursor += n;
     }

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -6,6 +6,17 @@ use crate::{
     medium::MctpMedium,
 };
 
+pub(crate) fn map_decode_err<M: MctpMedium>(
+    e: DecodeError,
+    on_premature: &'static str,
+    on_escape: &'static str,
+) -> MctpPacketError<M> {
+    match e {
+        DecodeError::PrematureEnd => MctpPacketError::HeaderParseError(on_premature),
+        DecodeError::InvalidEscape => MctpPacketError::HeaderParseError(on_escape),
+    }
+}
+
 pub(crate) fn parse_transport_header<M: MctpMedium>(
     decoder: &mut EncodingDecoder<'_, M::Encoding>,
 ) -> MctpPacketResult<MctpTransportHeader, M> {
@@ -18,13 +29,12 @@ pub(crate) fn parse_transport_header<M: MctpMedium>(
     // bytes).
     let mut header_bytes = [0u8; 4];
     for slot in header_bytes.iter_mut() {
-        *slot = decoder.read().map_err(|e| match e {
-            DecodeError::PrematureEnd => MctpPacketError::HeaderParseError(
+        *slot = decoder.read().map_err(|e| {
+            map_decode_err::<M>(
+                e,
                 "Packet is too small, cannot parse transport header",
-            ),
-            DecodeError::InvalidEscape => MctpPacketError::HeaderParseError(
                 "Invalid encoding escape sequence in transport header",
-            ),
+            )
         })?;
     }
     let transport_header_value = u32::from_be_bytes(header_bytes);

--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -1,39 +1,35 @@
 use crate::{
     MctpMessageBuffer, MctpPacketError,
-    buffer_encoding::{BufferEncoding, DecodeError},
+    buffer_encoding::{DecodeError, EncodingDecoder},
     error::MctpPacketResult,
     mctp_transport_header::MctpTransportHeader,
     medium::MctpMedium,
 };
 
 pub(crate) fn parse_transport_header<M: MctpMedium>(
-    packet: &[u8],
-) -> MctpPacketResult<(MctpTransportHeader, &[u8]), M> {
-    // Walk 4 decoded bytes through the medium's BufferEncoding. We do NOT
-    // pre-check `packet.len() < 4` because for stuffing encodings that's
-    // misleading: wire length is not decoded length. PrematureEnd from
-    // read_byte is the canonical "ran out of bytes while decoding the header"
-    // signal — it correctly handles BOTH the Passthrough case (wire < 4) AND
-    // the stuffing case (wire >= 4 but yields < 4 decoded bytes).
+    decoder: &mut EncodingDecoder<'_, M::Encoding>,
+) -> MctpPacketResult<MctpTransportHeader, M> {
+    // Read 4 decoded bytes through the encoding-aware decoder. We do NOT
+    // pre-check `decoder.remaining_wire() < 4` because for stuffing
+    // encodings wire length is not decoded length; PrematureEnd from
+    // `read()` is the canonical "ran out of bytes while decoding the
+    // header" signal — it correctly handles BOTH the Passthrough case
+    // (wire < 4) AND the stuffing case (wire >= 4 but yields < 4 decoded
+    // bytes).
     let mut header_bytes = [0u8; 4];
-    let mut wire_cursor = 0;
     for slot in header_bytes.iter_mut() {
-        let (byte, n) = <M::Encoding as BufferEncoding>::read_byte(&packet[wire_cursor..])
-            .map_err(|e| match e {
-                DecodeError::PrematureEnd => MctpPacketError::HeaderParseError(
-                    "Packet is too small, cannot parse transport header",
-                ),
-                DecodeError::InvalidEscape => MctpPacketError::HeaderParseError(
-                    "Invalid encoding escape sequence in transport header",
-                ),
-            })?;
-        *slot = byte;
-        wire_cursor += n;
+        *slot = decoder.read().map_err(|e| match e {
+            DecodeError::PrematureEnd => MctpPacketError::HeaderParseError(
+                "Packet is too small, cannot parse transport header",
+            ),
+            DecodeError::InvalidEscape => MctpPacketError::HeaderParseError(
+                "Invalid encoding escape sequence in transport header",
+            ),
+        })?;
     }
     let transport_header_value = u32::from_be_bytes(header_bytes);
-    let transport_header = MctpTransportHeader::try_from(transport_header_value)
-        .map_err(|_| MctpPacketError::HeaderParseError("Invalid transport header"))?;
-    Ok((transport_header, &packet[wire_cursor..]))
+    MctpTransportHeader::try_from(transport_header_value)
+        .map_err(|_| MctpPacketError::HeaderParseError("Invalid transport header"))
 }
 
 pub(crate) fn parse_message_body<M: MctpMedium>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //! # use mctp_rs::*;
 //! # #[derive(Debug, Clone, Copy)] struct MyMedium { mtu: usize }
 //! # #[derive(Debug, Clone, Copy)] struct MyMediumFrame { packet_size: usize }
-//! # impl MctpMedium for MyMedium { type Frame=MyMediumFrame; type Error=&'static str; type ReplyContext=();
+//! # impl MctpMedium for MyMedium { type Frame=MyMediumFrame; type Error=&'static str; type ReplyContext=(); type Encoding=PassthroughEncoding;
 //! #   fn max_message_body_size(&self)->usize{self.mtu}
 //! #   fn deserialize<'b>(&self,p:&'b [u8])->MctpPacketResult<(Self::Frame,&'b [u8]),Self>{Ok((MyMediumFrame{packet_size:p.len()},p))}
 //! #   fn serialize<'b,F>(&self,_:Self::ReplyContext,b:&'b mut [u8],w:F)->MctpPacketResult<&'b [u8],Self> where F: for<'a> FnOnce(&'a mut [u8])->MctpPacketResult<usize,Self>{let n=w(b)?;Ok(&b[..n])}}
@@ -59,7 +59,7 @@
 //! # use mctp_rs::*;
 //! # #[derive(Debug, Clone, Copy)] struct MyMedium { mtu: usize }
 //! # #[derive(Debug, Clone, Copy)] struct MyMediumFrame { packet_size: usize }
-//! # impl MctpMedium for MyMedium { type Frame=MyMediumFrame; type Error=&'static str; type ReplyContext=(); fn max_message_body_size(&self)->usize{self.mtu}
+//! # impl MctpMedium for MyMedium { type Frame=MyMediumFrame; type Error=&'static str; type ReplyContext=(); type Encoding=PassthroughEncoding; fn max_message_body_size(&self)->usize{self.mtu}
 //! #   fn deserialize<'b>(&self,p:&'b [u8])->MctpPacketResult<(Self::Frame,&'b [u8]),Self>{Ok((MyMediumFrame{packet_size:p.len()},p))}
 //! #   fn serialize<'b,F>(&self,_:Self::ReplyContext,b:&'b mut [u8],w:F)->MctpPacketResult<&'b [u8],Self> where F: for<'a> FnOnce(&'a mut [u8])->MctpPacketResult<usize,Self>{let n=w(b)?;Ok(&b[..n])}}
 //! # impl MctpMediumFrame<MyMedium> for MyMediumFrame { fn packet_size(&self)->usize{self.packet_size} fn reply_context(&self)->(){()}}
@@ -109,6 +109,7 @@
 //!     type Frame = MyMediumFrame;
 //!     type Error = &'static str;
 //!     type ReplyContext = ();
+//!     type Encoding = PassthroughEncoding;
 //!
 //!     fn max_message_body_size(&self) -> usize {
 //!         self.mtu
@@ -152,6 +153,7 @@
 //! }
 //! ```
 
+mod buffer_encoding;
 mod deserialize;
 mod endpoint_id;
 pub mod error;
@@ -167,6 +169,10 @@ mod serialize;
 #[cfg(test)]
 mod test_util;
 
+pub use buffer_encoding::{
+    BufferEncoding, DecodeError as BufferDecodeError, EncodeError as BufferEncodeError,
+    PassthroughEncoding,
+};
 pub use endpoint_id::EndpointId;
 pub use error::{MctpPacketError, MctpPacketResult};
 pub use mctp_message_tag::MctpMessageTag;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,8 @@
 //! # #[derive(Debug, Clone, Copy)] struct MyMediumFrame { packet_size: usize }
 //! # impl MctpMedium for MyMedium { type Frame=MyMediumFrame; type Error=&'static str; type ReplyContext=(); type Encoding=PassthroughEncoding;
 //! #   fn max_message_body_size(&self)->usize{self.mtu}
-//! #   fn deserialize<'b>(&self,p:&'b [u8])->MctpPacketResult<(Self::Frame,&'b [u8]),Self>{Ok((MyMediumFrame{packet_size:p.len()},p))}
-//! #   fn serialize<'b,F>(&self,_:Self::ReplyContext,b:&'b mut [u8],w:F)->MctpPacketResult<&'b [u8],Self> where F: for<'a> FnOnce(&'a mut [u8])->MctpPacketResult<usize,Self>{let n=w(b)?;Ok(&b[..n])}}
+//! #   fn deserialize<'b>(&self,p:&'b [u8])->MctpPacketResult<(Self::Frame,EncodingDecoder<'b,Self::Encoding>),Self>{Ok((MyMediumFrame{packet_size:p.len()},EncodingDecoder::new(p)))}
+//! #   fn serialize<'b,F>(&self,_:Self::ReplyContext,b:&'b mut [u8],w:F)->MctpPacketResult<&'b [u8],Self> where F: for<'a> FnOnce(&mut EncodingEncoder<'a,Self::Encoding>)->MctpPacketResult<(),Self>{let n={let mut e=EncodingEncoder::<Self::Encoding>::new(b);w(&mut e)?;e.wire_position()};Ok(&b[..n])}}
 //! # impl MctpMediumFrame<MyMedium> for MyMediumFrame { fn packet_size(&self)->usize{self.packet_size} fn reply_context(&self)->(){()}}
 //! let mut assembly_buffer = [0u8; 1024];
 //! let medium = MyMedium { mtu: 256 };
@@ -60,8 +60,8 @@
 //! # #[derive(Debug, Clone, Copy)] struct MyMedium { mtu: usize }
 //! # #[derive(Debug, Clone, Copy)] struct MyMediumFrame { packet_size: usize }
 //! # impl MctpMedium for MyMedium { type Frame=MyMediumFrame; type Error=&'static str; type ReplyContext=(); type Encoding=PassthroughEncoding; fn max_message_body_size(&self)->usize{self.mtu}
-//! #   fn deserialize<'b>(&self,p:&'b [u8])->MctpPacketResult<(Self::Frame,&'b [u8]),Self>{Ok((MyMediumFrame{packet_size:p.len()},p))}
-//! #   fn serialize<'b,F>(&self,_:Self::ReplyContext,b:&'b mut [u8],w:F)->MctpPacketResult<&'b [u8],Self> where F: for<'a> FnOnce(&'a mut [u8])->MctpPacketResult<usize,Self>{let n=w(b)?;Ok(&b[..n])}}
+//! #   fn deserialize<'b>(&self,p:&'b [u8])->MctpPacketResult<(Self::Frame,EncodingDecoder<'b,Self::Encoding>),Self>{Ok((MyMediumFrame{packet_size:p.len()},EncodingDecoder::new(p)))}
+//! #   fn serialize<'b,F>(&self,_:Self::ReplyContext,b:&'b mut [u8],w:F)->MctpPacketResult<&'b [u8],Self> where F: for<'a> FnOnce(&mut EncodingEncoder<'a,Self::Encoding>)->MctpPacketResult<(),Self>{let n={let mut e=EncodingEncoder::<Self::Encoding>::new(b);w(&mut e)?;e.wire_position()};Ok(&b[..n])}}
 //! # impl MctpMediumFrame<MyMedium> for MyMediumFrame { fn packet_size(&self)->usize{self.packet_size} fn reply_context(&self)->(){()}}
 //! let mut buf = [0u8; 1024];
 //! let mut ctx = MctpPacketContext::new(MyMedium { mtu: 64 }, &mut buf);
@@ -118,13 +118,13 @@
 //!     fn deserialize<'buf>(
 //!         &self,
 //!         packet: &'buf [u8],
-//!     ) -> MctpPacketResult<(Self::Frame, &'buf [u8]), Self> {
+//!     ) -> MctpPacketResult<(Self::Frame, EncodingDecoder<'buf, Self::Encoding>), Self> {
 //!         // Strip/validate transport headers as needed for your bus and return MCTP payload slice
 //!         Ok((
 //!             MyMediumFrame {
 //!                 packet_size: packet.len(),
 //!             },
-//!             packet,
+//!             EncodingDecoder::new(packet),
 //!         ))
 //!     }
 //!
@@ -135,11 +135,17 @@
 //!         message_writer: F,
 //!     ) -> MctpPacketResult<&'buf [u8], Self>
 //!     where
-//!         F: for<'a> FnOnce(&'a mut [u8]) -> MctpPacketResult<usize, Self>,
+//!         F: for<'a> FnOnce(
+//!             &mut EncodingEncoder<'a, Self::Encoding>,
+//!         ) -> MctpPacketResult<(), Self>,
 //!     {
 //!         // Prepend transport headers as needed, then ask the writer to write MCTP payload
-//!         let message_len = message_writer(buffer)?;
-//!         Ok(&buffer[..message_len])
+//!         let written = {
+//!             let mut encoder = EncodingEncoder::<Self::Encoding>::new(buffer);
+//!             message_writer(&mut encoder)?;
+//!             encoder.wire_position()
+//!         };
+//!         Ok(&buffer[..written])
 //!     }
 //! }
 //!
@@ -171,7 +177,7 @@ mod test_util;
 
 pub use buffer_encoding::{
     BufferEncoding, DecodeError as BufferDecodeError, EncodeError as BufferEncodeError,
-    PassthroughEncoding,
+    EncodingDecoder, EncodingEncoder, PassthroughEncoding,
 };
 pub use endpoint_id::EndpointId;
 pub use error::{MctpPacketError, MctpPacketResult};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,8 +176,7 @@ mod serialize;
 mod test_util;
 
 pub use buffer_encoding::{
-    BufferEncoding, DecodeError as BufferDecodeError, EncodeError as BufferEncodeError,
-    EncodingDecoder, EncodingEncoder, PassthroughEncoding,
+    BufferEncoding, DecodeError, EncodeError, EncodingDecoder, EncodingEncoder, PassthroughEncoding,
 };
 pub use endpoint_id::EndpointId;
 pub use error::{MctpPacketError, MctpPacketResult};

--- a/src/mctp_packet_context.rs
+++ b/src/mctp_packet_context.rs
@@ -1,6 +1,6 @@
 use crate::{
     MctpMessage, MctpMessageHeaderTrait, MctpMessageTrait, MctpPacketError,
-    buffer_encoding::{BufferEncoding, DecodeError},
+    buffer_encoding::DecodeError,
     deserialize::{parse_message_body, parse_transport_header},
     endpoint_id::EndpointId,
     error::{MctpPacketResult, ProtocolError},
@@ -44,8 +44,8 @@ impl<'buf, M: MctpMedium> MctpPacketContext<'buf, M> {
         &mut self,
         packet: &[u8],
     ) -> MctpPacketResult<Option<MctpMessage<'_, M>>, M> {
-        let (medium_frame, packet) = self.medium.deserialize(packet)?;
-        let (transport_header, packet) = parse_transport_header::<M>(packet)?;
+        let (medium_frame, mut decoder) = self.medium.deserialize(packet)?;
+        let transport_header = parse_transport_header::<M>(&mut decoder)?;
 
         let mut state = match self.assembly_state {
             AssemblyState::Idle => {
@@ -121,23 +121,21 @@ impl<'buf, M: MctpMedium> MctpPacketContext<'buf, M> {
             ));
         }
         // Decode `packet_size` payload bytes from the (possibly stuffed) wire
-        // buffer into the assembly buffer one byte at a time. We do NOT
-        // pre-check `packet.len() < packet_size` because for stuffing encodings
-        // wire length is not decoded length. PrematureEnd from read_byte is
-        // the canonical "ran out of bytes while decoding the body" signal.
-        let mut wire_cursor = 0;
+        // buffer into the assembly buffer one byte at a time via the
+        // medium-supplied decoder. We do NOT pre-check
+        // `decoder.remaining_wire() < packet_size` because for stuffing
+        // encodings wire length is not decoded length; PrematureEnd from
+        // `read()` is the canonical "ran out of bytes while decoding the
+        // body" signal.
         for i in 0..packet_size {
-            let (byte, n) = <M::Encoding as BufferEncoding>::read_byte(&packet[wire_cursor..])
-                .map_err(|e| match e {
-                    DecodeError::PrematureEnd => MctpPacketError::HeaderParseError(
-                        "packet body too short to extract expected decoded bytes",
-                    ),
-                    DecodeError::InvalidEscape => MctpPacketError::HeaderParseError(
-                        "Invalid encoding escape sequence in packet body",
-                    ),
-                })?;
-            self.packet_assembly_buffer[buffer_idx + i] = byte;
-            wire_cursor += n;
+            self.packet_assembly_buffer[buffer_idx + i] = decoder.read().map_err(|e| match e {
+                DecodeError::PrematureEnd => MctpPacketError::HeaderParseError(
+                    "packet body too short to extract expected decoded bytes",
+                ),
+                DecodeError::InvalidEscape => MctpPacketError::HeaderParseError(
+                    "Invalid encoding escape sequence in packet body",
+                ),
+            })?;
         }
         state.packet_assembly_buffer_index += packet_size;
 

--- a/src/mctp_packet_context.rs
+++ b/src/mctp_packet_context.rs
@@ -1,5 +1,6 @@
 use crate::{
     MctpMessage, MctpMessageHeaderTrait, MctpMessageTrait, MctpPacketError,
+    buffer_encoding::{BufferEncoding, DecodeError},
     deserialize::{parse_message_body, parse_transport_header},
     endpoint_id::EndpointId,
     error::{MctpPacketResult, ProtocolError},
@@ -124,8 +125,24 @@ impl<'buf, M: MctpMedium> MctpPacketContext<'buf, M> {
                 "packet assembly buffer overflow - insufficient space",
             ));
         }
-        self.packet_assembly_buffer[buffer_idx..buffer_idx + packet_size]
-            .copy_from_slice(&packet[..packet_size]);
+        // Decode `packet_size` payload bytes from the (possibly stuffed) wire
+        // buffer into the assembly buffer one byte at a time. For
+        // PassthroughEncoding this is observably equivalent to copy_from_slice;
+        // for stuffing encodings, wire bytes consumed per decoded byte is variable.
+        let mut wire_cursor = 0;
+        for i in 0..packet_size {
+            let (byte, n) = <M::Encoding as BufferEncoding>::read_byte(&packet[wire_cursor..])
+                .map_err(|e| match e {
+                    DecodeError::PrematureEnd => {
+                        MctpPacketError::HeaderParseError("encoding: premature end of buffer")
+                    }
+                    DecodeError::InvalidEscape => {
+                        MctpPacketError::HeaderParseError("encoding: invalid escape sequence")
+                    }
+                })?;
+            self.packet_assembly_buffer[buffer_idx + i] = byte;
+            wire_cursor += n;
+        }
         state.packet_assembly_buffer_index += packet_size;
 
         let message = if transport_header.end_of_message == 1 {

--- a/src/mctp_packet_context.rs
+++ b/src/mctp_packet_context.rs
@@ -114,31 +114,27 @@ impl<'buf, M: MctpMedium> MctpPacketContext<'buf, M> {
             ));
         }
         let packet_size = packet_size - 4; // to account for the transport header
-        if packet.len() < packet_size {
-            return Err(MctpPacketError::HeaderParseError(
-                "packet.len() < packet_size",
-            ));
-        }
-        // Check bounds to prevent buffer overflow
+        // Check assembly buffer bounds (decoded bytes destination)
         if buffer_idx + packet_size > self.packet_assembly_buffer.len() {
             return Err(MctpPacketError::HeaderParseError(
                 "packet assembly buffer overflow - insufficient space",
             ));
         }
         // Decode `packet_size` payload bytes from the (possibly stuffed) wire
-        // buffer into the assembly buffer one byte at a time. For
-        // PassthroughEncoding this is observably equivalent to copy_from_slice;
-        // for stuffing encodings, wire bytes consumed per decoded byte is variable.
+        // buffer into the assembly buffer one byte at a time. We do NOT
+        // pre-check `packet.len() < packet_size` because for stuffing encodings
+        // wire length is not decoded length. PrematureEnd from read_byte is
+        // the canonical "ran out of bytes while decoding the body" signal.
         let mut wire_cursor = 0;
         for i in 0..packet_size {
             let (byte, n) = <M::Encoding as BufferEncoding>::read_byte(&packet[wire_cursor..])
                 .map_err(|e| match e {
-                    DecodeError::PrematureEnd => {
-                        MctpPacketError::HeaderParseError("encoding: premature end of buffer")
-                    }
-                    DecodeError::InvalidEscape => {
-                        MctpPacketError::HeaderParseError("encoding: invalid escape sequence")
-                    }
+                    DecodeError::PrematureEnd => MctpPacketError::HeaderParseError(
+                        "packet body too short to extract expected decoded bytes",
+                    ),
+                    DecodeError::InvalidEscape => MctpPacketError::HeaderParseError(
+                        "Invalid encoding escape sequence in packet body",
+                    ),
                 })?;
             self.packet_assembly_buffer[buffer_idx + i] = byte;
             wire_cursor += n;

--- a/src/mctp_packet_context.rs
+++ b/src/mctp_packet_context.rs
@@ -1,7 +1,6 @@
 use crate::{
     MctpMessage, MctpMessageHeaderTrait, MctpMessageTrait, MctpPacketError,
-    buffer_encoding::DecodeError,
-    deserialize::{parse_message_body, parse_transport_header},
+    deserialize::{map_decode_err, parse_message_body, parse_transport_header},
     endpoint_id::EndpointId,
     error::{MctpPacketResult, ProtocolError},
     mctp_message_tag::MctpMessageTag,
@@ -128,13 +127,12 @@ impl<'buf, M: MctpMedium> MctpPacketContext<'buf, M> {
         // `read()` is the canonical "ran out of bytes while decoding the
         // body" signal.
         for i in 0..packet_size {
-            self.packet_assembly_buffer[buffer_idx + i] = decoder.read().map_err(|e| match e {
-                DecodeError::PrematureEnd => MctpPacketError::HeaderParseError(
+            self.packet_assembly_buffer[buffer_idx + i] = decoder.read().map_err(|e| {
+                map_decode_err::<M>(
+                    e,
                     "packet body too short to extract expected decoded bytes",
-                ),
-                DecodeError::InvalidEscape => MctpPacketError::HeaderParseError(
                     "Invalid encoding escape sequence in packet body",
-                ),
+                )
             })?;
         }
         state.packet_assembly_buffer_index += packet_size;

--- a/src/medium/mod.rs
+++ b/src/medium/mod.rs
@@ -42,8 +42,7 @@ pub trait MctpMedium: Sized {
     /// through an [`EncodingEncoder`]. The medium owns its outer framing
     /// (e.g., SMBus header + PEC, DSP0253 start/end flags + FCS) and
     /// inspects the encoder's
-    /// [`wire_position`](EncodingEncoder::wire_position) /
-    /// [`decoded_count`](EncodingEncoder::decoded_count) after the
+    /// [`wire_position`](EncodingEncoder::wire_position) after the
     /// closure returns to size headers/trailers and compute checksums.
     fn serialize<'buf, F>(
         &self,

--- a/src/medium/mod.rs
+++ b/src/medium/mod.rs
@@ -1,4 +1,4 @@
-use crate::error::MctpPacketResult;
+use crate::{buffer_encoding::BufferEncoding, error::MctpPacketResult};
 
 pub mod smbus_espi;
 mod util;
@@ -12,6 +12,13 @@ pub trait MctpMedium: Sized {
 
     // the type used for the data needed to send a reply to a request
     type ReplyContext: core::fmt::Debug + Copy + Clone + PartialEq + Eq;
+
+    /// the byte-stuffing transform used by this medium when (de)serializing
+    /// wire bytes. Stateless — see [`crate::buffer_encoding`]. Most media
+    /// use [`PassthroughEncoding`](crate::buffer_encoding::PassthroughEncoding)
+    /// (no transform); media that need byte-stuffing (e.g., DSP0253 serial)
+    /// supply their own impl.
+    type Encoding: BufferEncoding;
 
     /// the maximum transmission unit for the medium
     fn max_message_body_size(&self) -> usize;

--- a/src/medium/mod.rs
+++ b/src/medium/mod.rs
@@ -1,4 +1,7 @@
-use crate::{buffer_encoding::BufferEncoding, error::MctpPacketResult};
+use crate::{
+    buffer_encoding::{BufferEncoding, EncodingDecoder, EncodingEncoder},
+    error::MctpPacketResult,
+};
 
 pub mod smbus_espi;
 mod util;
@@ -23,14 +26,25 @@ pub trait MctpMedium: Sized {
     /// the maximum transmission unit for the medium
     fn max_message_body_size(&self) -> usize;
 
-    /// deserialize the packet into the medium specific header and remainder of the packet -
-    /// this includes the mctp transport header, and mctp packet payload
+    /// Deserialize a packet into the medium-specific header (frame) and an
+    /// [`EncodingDecoder`] that wraps the inner stuffed-region bytes.
+    /// Higher layers (e.g., `parse_transport_header`, the payload copy
+    /// loop in `MctpPacketContext`) read decoded bytes through the
+    /// returned decoder and physically cannot bypass the medium's
+    /// encoding by slicing the underlying buffer directly.
     fn deserialize<'buf>(
         &self,
         packet: &'buf [u8],
-    ) -> MctpPacketResult<(Self::Frame, &'buf [u8]), Self>;
+    ) -> MctpPacketResult<(Self::Frame, EncodingDecoder<'buf, Self::Encoding>), Self>;
 
-    /// serialize the packet into the medium specific header and the payload
+    /// Serialize a packet by allowing the caller's `message_writer`
+    /// closure to write decoded bytes into the medium's stuffed region
+    /// through an [`EncodingEncoder`]. The medium owns its outer framing
+    /// (e.g., SMBus header + PEC, DSP0253 start/end flags + FCS) and
+    /// inspects the encoder's
+    /// [`wire_position`](EncodingEncoder::wire_position) /
+    /// [`decoded_count`](EncodingEncoder::decoded_count) after the
+    /// closure returns to size headers/trailers and compute checksums.
     fn serialize<'buf, F>(
         &self,
         reply_context: Self::ReplyContext,
@@ -38,7 +52,7 @@ pub trait MctpMedium: Sized {
         message_writer: F,
     ) -> MctpPacketResult<&'buf [u8], Self>
     where
-        F: for<'a> FnOnce(&'a mut [u8]) -> MctpPacketResult<usize, Self>;
+        F: for<'a> FnOnce(&mut EncodingEncoder<'a, Self::Encoding>) -> MctpPacketResult<(), Self>;
 }
 
 pub trait MctpMediumFrame<M: MctpMedium>: Clone + Copy {

--- a/src/medium/smbus_espi.rs
+++ b/src/medium/smbus_espi.rs
@@ -79,13 +79,12 @@ impl MctpMedium for SmbusEspiMedium {
 
         // Write the body first via an encoder over the body region (reserve
         // 4 leading header bytes and 1 trailing PEC byte).
-        let body_wire_len: usize;
-        {
+        let body_wire_len = {
             let body_buf = &mut buffer[4..buffer_len - 1];
             let mut encoder = EncodingEncoder::<Self::Encoding>::new(body_buf);
             message_writer(&mut encoder)?;
-            body_wire_len = encoder.wire_position();
-        }
+            encoder.wire_position()
+        };
 
         // with the body has been written, construct the header. byte_count
         // is the number of wire bytes that follow on the line per SMBus

--- a/src/medium/smbus_espi.rs
+++ b/src/medium/smbus_espi.rs
@@ -24,6 +24,7 @@ impl MctpMedium for SmbusEspiMedium {
     type Frame = SmbusEspiMediumFrame;
     type Error = &'static str;
     type ReplyContext = SmbusEspiReplyContext;
+    type Encoding = crate::buffer_encoding::PassthroughEncoding;
 
     fn deserialize<'buf>(
         &self,

--- a/src/medium/smbus_espi.rs
+++ b/src/medium/smbus_espi.rs
@@ -80,21 +80,21 @@ impl MctpMedium for SmbusEspiMedium {
         // Write the body first via an encoder over the body region (reserve
         // 4 leading header bytes and 1 trailing PEC byte).
         let body_wire_len: usize;
-        let body_decoded_len: usize;
         {
             let body_buf = &mut buffer[4..buffer_len - 1];
             let mut encoder = EncodingEncoder::<Self::Encoding>::new(body_buf);
             message_writer(&mut encoder)?;
             body_wire_len = encoder.wire_position();
-            body_decoded_len = encoder.decoded_count();
         }
 
         // with the body has been written, construct the header. byte_count
-        // is the DECODED count per SMBus convention.
+        // is the number of wire bytes that follow on the line per SMBus
+        // (PassthroughEncoding pairing means wire byte count == decoded
+        // byte count for SMBus today).
         let header = SmbusEspiMediumHeader {
             destination_slave_address: reply_context.source_slave_address,
             source_slave_address: reply_context.destination_slave_address,
-            byte_count: body_decoded_len as u8,
+            byte_count: body_wire_len as u8,
             command_code: SmbusCommandCode::Mctp,
             ..Default::default()
         };

--- a/src/medium/smbus_espi.rs
+++ b/src/medium/smbus_espi.rs
@@ -194,9 +194,7 @@ mod tests {
 
     /// Test-only helper: drain an `EncodingDecoder` to a `Vec<u8>` for
     /// content assertions. Stops at the first error (e.g., `PrematureEnd`).
-    fn drain_to_vec<E: crate::buffer_encoding::BufferEncoding>(
-        decoder: &mut crate::buffer_encoding::EncodingDecoder<'_, E>,
-    ) -> Vec<u8> {
+    fn drain_to_vec(decoder: &mut EncodingDecoder<'_, PassthroughEncoding>) -> Vec<u8> {
         let mut out = Vec::new();
         while let Ok(b) = decoder.read() {
             out.push(b);

--- a/src/medium/smbus_espi.rs
+++ b/src/medium/smbus_espi.rs
@@ -191,6 +191,7 @@ mod tests {
     use std::vec::Vec;
 
     use super::*;
+    use crate::buffer_encoding::DecodeError;
 
     /// Test-only helper: drain an `EncodingDecoder` to a `Vec<u8>` for
     /// content assertions. Stops at the first error (e.g., `PrematureEnd`).
@@ -322,11 +323,11 @@ mod tests {
         packet[4] = pec;
 
         let result = medium.deserialize(&packet).unwrap();
-        let (frame, decoder) = result;
+        let (frame, mut decoder) = result;
 
         assert_eq!(frame.header.byte_count, 0);
         assert_eq!(frame.pec, pec);
-        assert_eq!(decoder.remaining_wire(), 0);
+        assert_eq!(decoder.read().unwrap_err(), DecodeError::PrematureEnd);
     }
 
     #[test]

--- a/src/medium/smbus_espi.rs
+++ b/src/medium/smbus_espi.rs
@@ -2,6 +2,7 @@ use bit_register::{NumBytes, TryFromBits, TryIntoBits, bit_register};
 
 use crate::{
     MctpPacketError,
+    buffer_encoding::{EncodingDecoder, EncodingEncoder, PassthroughEncoding},
     error::MctpPacketResult,
     medium::{
         MctpMedium, MctpMediumFrame,
@@ -24,12 +25,12 @@ impl MctpMedium for SmbusEspiMedium {
     type Frame = SmbusEspiMediumFrame;
     type Error = &'static str;
     type ReplyContext = SmbusEspiReplyContext;
-    type Encoding = crate::buffer_encoding::PassthroughEncoding;
+    type Encoding = PassthroughEncoding;
 
     fn deserialize<'buf>(
         &self,
         packet: &'buf [u8],
-    ) -> MctpPacketResult<(Self::Frame, &'buf [u8]), Self> {
+    ) -> MctpPacketResult<(Self::Frame, EncodingDecoder<'buf, Self::Encoding>), Self> {
         // Check if packet has enough bytes for header
         if packet.len() < 4 {
             return Err(MctpPacketError::MediumError(
@@ -51,9 +52,12 @@ impl MctpMedium for SmbusEspiMedium {
             ));
         }
         let pec = packet[header.byte_count as usize];
-        // strip off the PEC byte
-        let packet = &packet[..header.byte_count as usize];
-        Ok((SmbusEspiMediumFrame { header, pec }, packet))
+        // strip off the PEC byte; the inner stuffed region is the body bytes
+        let inner = &packet[..header.byte_count as usize];
+        Ok((
+            SmbusEspiMediumFrame { header, pec },
+            EncodingDecoder::new(inner),
+        ))
     }
 
     fn serialize<'buf, F>(
@@ -63,7 +67,7 @@ impl MctpMedium for SmbusEspiMedium {
         message_writer: F,
     ) -> MctpPacketResult<&'buf [u8], Self>
     where
-        F: for<'a> FnOnce(&'a mut [u8]) -> MctpPacketResult<usize, Self>,
+        F: for<'a> FnOnce(&mut EncodingEncoder<'a, Self::Encoding>) -> MctpPacketResult<(), Self>,
     {
         // Reserve space for header (4 bytes) and PEC (1 byte)
         if buffer.len() < 5 {
@@ -71,35 +75,39 @@ impl MctpMedium for SmbusEspiMedium {
                 "Buffer too small for smbus frame",
             ));
         }
+        let buffer_len = buffer.len();
 
-        // split off a buffer where we will write the header, the rest is for body + PEC
-        let (header_slice, body) = buffer.split_at_mut(4);
-
-        // Write the body first, but ensure we leave space for PEC
-        if body.is_empty() {
-            return Err(MctpPacketError::MediumError("No space for PEC byte"));
+        // Write the body first via an encoder over the body region (reserve
+        // 4 leading header bytes and 1 trailing PEC byte).
+        let body_wire_len: usize;
+        let body_decoded_len: usize;
+        {
+            let body_buf = &mut buffer[4..buffer_len - 1];
+            let mut encoder = EncodingEncoder::<Self::Encoding>::new(body_buf);
+            message_writer(&mut encoder)?;
+            body_wire_len = encoder.wire_position();
+            body_decoded_len = encoder.decoded_count();
         }
-        let available_body_len = body.len() - 1; // Reserve 1 byte for PEC
-        let body_len = message_writer(&mut body[..available_body_len])?;
 
-        // with the body has been written, construct the header
+        // with the body has been written, construct the header. byte_count
+        // is the DECODED count per SMBus convention.
         let header = SmbusEspiMediumHeader {
             destination_slave_address: reply_context.source_slave_address,
             source_slave_address: reply_context.destination_slave_address,
-            byte_count: body_len as u8,
+            byte_count: body_decoded_len as u8,
             command_code: SmbusCommandCode::Mctp,
             ..Default::default()
         };
         let header_value =
             TryInto::<u32>::try_into(header).map_err(MctpPacketError::MediumError)?;
-        header_slice.copy_from_slice(&header_value.to_be_bytes());
+        buffer[0..4].copy_from_slice(&header_value.to_be_bytes());
 
         // with the header written, compute the PEC byte
-        let pec_value = smbus_pec::pec(&buffer[0..4 + body_len]);
-        buffer[4 + body_len] = pec_value;
+        let pec_value = smbus_pec::pec(&buffer[0..4 + body_wire_len]);
+        buffer[4 + body_wire_len] = pec_value;
 
         // add 4 for frame header, add 1 for PEC byte
-        Ok(&buffer[0..4 + body_len + 1])
+        Ok(&buffer[0..4 + body_wire_len + 1])
     }
 
     // TODO - this is a guess, need to find the actual value from spec
@@ -180,7 +188,21 @@ impl MctpMediumFrame<SmbusEspiMedium> for SmbusEspiMediumFrame {
 #[cfg(test)]
 mod tests {
     extern crate std;
+    use std::vec::Vec;
+
     use super::*;
+
+    /// Test-only helper: drain an `EncodingDecoder` to a `Vec<u8>` for
+    /// content assertions. Stops at the first error (e.g., `PrematureEnd`).
+    fn drain_to_vec<E: crate::buffer_encoding::BufferEncoding>(
+        decoder: &mut crate::buffer_encoding::EncodingDecoder<'_, E>,
+    ) -> Vec<u8> {
+        let mut out = Vec::new();
+        while let Ok(b) = decoder.read() {
+            out.push(b);
+        }
+        out
+    }
 
     #[test]
     fn test_deserialize_valid_packet() {
@@ -210,14 +232,15 @@ mod tests {
         packet[8] = pec;
 
         let result = medium.deserialize(&packet).unwrap();
-        let (frame, body) = result;
+        let (frame, mut decoder) = result;
+        let body = drain_to_vec(&mut decoder);
 
         assert_eq!(frame.header.destination_slave_address, 0x20);
         assert_eq!(frame.header.source_slave_address, 0x10);
         assert_eq!(frame.header.command_code, SmbusCommandCode::Mctp);
         assert_eq!(frame.header.byte_count, 4);
         assert_eq!(frame.pec, pec);
-        assert_eq!(body, &payload);
+        assert_eq!(body, payload);
     }
 
     #[test]
@@ -225,12 +248,10 @@ mod tests {
         let medium = SmbusEspiMedium;
         let short_packet = [0x01, 0x02]; // Only 2 bytes, need at least 4 for header
 
-        let result = medium.deserialize(&short_packet);
+        let err = medium.deserialize(&short_packet).err().unwrap();
         assert_eq!(
-            result,
-            Err(MctpPacketError::MediumError(
-                "Packet too short to parse smbus header"
-            ))
+            err,
+            MctpPacketError::MediumError("Packet too short to parse smbus header")
         );
     }
 
@@ -252,12 +273,10 @@ mod tests {
         packet[0..4].copy_from_slice(&header_bytes);
         packet[4..6].copy_from_slice(&short_payload);
 
-        let result = medium.deserialize(&packet);
+        let err = medium.deserialize(&packet).err().unwrap();
         assert_eq!(
-            result,
-            Err(MctpPacketError::MediumError(
-                "Packet too short to parse smbus body and PEC"
-            ))
+            err,
+            MctpPacketError::MediumError("Packet too short to parse smbus body and PEC")
         );
     }
 
@@ -281,11 +300,8 @@ mod tests {
         packet[4..8].copy_from_slice(&payload);
         packet[8] = pec;
 
-        let result = medium.deserialize(&packet);
-        assert_eq!(
-            result,
-            Err(MctpPacketError::MediumError("Invalid smbus header"))
-        );
+        let err = medium.deserialize(&packet).err().unwrap();
+        assert_eq!(err, MctpPacketError::MediumError("Invalid smbus header"));
     }
 
     #[test]
@@ -306,11 +322,11 @@ mod tests {
         packet[4] = pec;
 
         let result = medium.deserialize(&packet).unwrap();
-        let (frame, body) = result;
+        let (frame, decoder) = result;
 
         assert_eq!(frame.header.byte_count, 0);
         assert_eq!(frame.pec, pec);
-        assert_eq!(body.len(), 0);
+        assert_eq!(decoder.remaining_wire(), 0);
     }
 
     #[test]
@@ -325,9 +341,10 @@ mod tests {
         let test_payload = [0xAA, 0xBB, 0xCC, 0xDD];
 
         let result = medium
-            .serialize(reply_context, &mut buffer, |buf| {
-                buf[..test_payload.len()].copy_from_slice(&test_payload);
-                Ok(test_payload.len())
+            .serialize(reply_context, &mut buffer, |encoder| {
+                encoder
+                    .write_all(&test_payload)
+                    .map_err(|_| MctpPacketError::SerializeError("encode error"))
             })
             .unwrap();
 
@@ -363,13 +380,14 @@ mod tests {
 
         let mut small_buffer = [0u8; 4]; // Only 4 bytes, need at least 5 (header + PEC)
 
-        let result = medium.serialize(reply_context, &mut small_buffer, |_| Ok(0));
+        let err = medium
+            .serialize(reply_context, &mut small_buffer, |_| Ok(()))
+            .err()
+            .unwrap();
 
         assert_eq!(
-            result,
-            Err(MctpPacketError::MediumError(
-                "Buffer too small for smbus frame"
-            ))
+            err,
+            MctpPacketError::MediumError("Buffer too small for smbus frame")
         );
     }
 
@@ -387,7 +405,7 @@ mod tests {
             .serialize(
                 reply_context,
                 &mut minimal_buffer,
-                |_| Ok(0), // No payload data
+                |_| Ok(()), // No payload data
             )
             .unwrap();
 
@@ -416,10 +434,10 @@ mod tests {
         let mut buffer = [0u8; 260]; // 4 + 255 + 1 = header + max payload + PEC
 
         let result = medium
-            .serialize(reply_context, &mut buffer, |buf| {
-                let copy_len = max_payload.len().min(buf.len());
-                buf[..copy_len].copy_from_slice(&max_payload[..copy_len]);
-                Ok(copy_len)
+            .serialize(reply_context, &mut buffer, |encoder| {
+                encoder
+                    .write_all(&max_payload)
+                    .map_err(|_| MctpPacketError::SerializeError("encode error"))
             })
             .unwrap();
 
@@ -468,17 +486,19 @@ mod tests {
 
         // Serialize
         let serialized = medium
-            .serialize(original_context, &mut buffer, |buf| {
-                buf[..original_payload.len()].copy_from_slice(&original_payload);
-                Ok(original_payload.len())
+            .serialize(original_context, &mut buffer, |encoder| {
+                encoder
+                    .write_all(&original_payload)
+                    .map_err(|_| MctpPacketError::SerializeError("encode error"))
             })
             .unwrap();
 
         // Deserialize
-        let (frame, deserialized_payload) = medium.deserialize(serialized).unwrap();
+        let (frame, mut decoder) = medium.deserialize(serialized).unwrap();
+        let deserialized_payload = drain_to_vec(&mut decoder);
 
         // Verify roundtrip correctness
-        assert_eq!(deserialized_payload, &original_payload);
+        assert_eq!(deserialized_payload, original_payload);
         assert_eq!(frame.header.destination_slave_address, 0x24); // swapped
         assert_eq!(frame.header.source_slave_address, 0x42); // swapped
         assert_eq!(frame.header.command_code, SmbusCommandCode::Mctp);
@@ -579,9 +599,10 @@ mod tests {
         let mut buffer = [0u8; 32];
 
         let result = medium
-            .serialize(reply_context, &mut buffer, |buf| {
-                buf[..test_data.len()].copy_from_slice(&test_data);
-                Ok(test_data.len())
+            .serialize(reply_context, &mut buffer, |encoder| {
+                encoder
+                    .write_all(&test_data)
+                    .map_err(|_| MctpPacketError::SerializeError("encode error"))
             })
             .unwrap();
 
@@ -607,7 +628,7 @@ mod tests {
             .serialize(
                 reply_context,
                 &mut buffer,
-                |_| Ok(0), // Empty payload
+                |_| Ok(()), // Empty payload
             )
             .unwrap();
 
@@ -652,7 +673,7 @@ mod tests {
         let mut buffer = [0u8; 16];
 
         let result = medium
-            .serialize(reply_context, &mut buffer, |_| Ok(0))
+            .serialize(reply_context, &mut buffer, |_| Ok(()))
             .unwrap();
 
         let header_value = u32::from_be_bytes([result[0], result[1], result[2], result[3]]);
@@ -690,7 +711,8 @@ mod tests {
 
             let packet_slice = &packet[0..4 + byte_count as usize + 1];
             let result = medium.deserialize(packet_slice).unwrap();
-            let (frame, body) = result;
+            let (frame, mut decoder) = result;
+            let body = drain_to_vec(&mut decoder);
 
             assert_eq!(frame.header.byte_count, byte_count);
             assert_eq!(body.len(), byte_count as usize);
@@ -717,12 +739,10 @@ mod tests {
         packet[4..6].copy_from_slice(&short_payload);
         packet[6] = 0x00; // PEC (doesn't matter for this test)
 
-        let result = medium.deserialize(&packet);
+        let err = medium.deserialize(&packet).err().unwrap();
         assert_eq!(
-            result,
-            Err(MctpPacketError::MediumError(
-                "Packet too short to parse smbus body and PEC"
-            ))
+            err,
+            MctpPacketError::MediumError("Packet too short to parse smbus body and PEC")
         );
     }
 
@@ -737,15 +757,16 @@ mod tests {
         // Test with buffer smaller than minimum required (4 header + 1 PEC = 5 bytes)
         let mut tiny_buffer = [0u8; 4]; // Only 4 bytes, need at least 5
 
-        let result = medium.serialize(reply_context, &mut tiny_buffer, |_| {
-            Ok(0) // No payload
-        });
+        let err = medium
+            .serialize(reply_context, &mut tiny_buffer, |_| {
+                Ok(()) // No payload
+            })
+            .err()
+            .unwrap();
 
         assert_eq!(
-            result,
-            Err(MctpPacketError::MediumError(
-                "Buffer too small for smbus frame"
-            ))
+            err,
+            MctpPacketError::MediumError("Buffer too small for smbus frame")
         );
     }
 
@@ -756,12 +777,13 @@ mod tests {
         // Test with packet shorter than header size (4 bytes)
         for packet_size in 0..4 {
             let short_packet = [0u8; 4];
-            let result = medium.deserialize(&short_packet[..packet_size]);
+            let err = medium
+                .deserialize(&short_packet[..packet_size])
+                .err()
+                .unwrap();
             assert_eq!(
-                result,
-                Err(MctpPacketError::MediumError(
-                    "Packet too short to parse smbus header"
-                ))
+                err,
+                MctpPacketError::MediumError("Packet too short to parse smbus header")
             );
         }
     }
@@ -784,12 +806,10 @@ mod tests {
         packet[0..4].copy_from_slice(&header_bytes);
         packet[4..9].copy_from_slice(&payload);
 
-        let result = medium.deserialize(&packet);
+        let err = medium.deserialize(&packet).err().unwrap();
         assert_eq!(
-            result,
-            Err(MctpPacketError::MediumError(
-                "Packet too short to parse smbus body and PEC"
-            ))
+            err,
+            MctpPacketError::MediumError("Packet too short to parse smbus body and PEC")
         );
     }
 
@@ -809,12 +829,10 @@ mod tests {
         let mut short_packet = [0u8; 4]; // Only header, no PEC
         short_packet.copy_from_slice(&header_bytes);
 
-        let result = medium.deserialize(&short_packet);
+        let err = medium.deserialize(&short_packet).err().unwrap();
         assert_eq!(
-            result,
-            Err(MctpPacketError::MediumError(
-                "Packet too short to parse smbus body and PEC"
-            ))
+            err,
+            MctpPacketError::MediumError("Packet too short to parse smbus body and PEC")
         );
     }
 
@@ -831,28 +849,31 @@ mod tests {
         let max_payload = [0x55u8; 255];
         let mut buffer = [0u8; 260]; // 4 + 255 + 1 = exactly enough
 
-        let result = medium.serialize(reply_context, &mut buffer, |buf| {
-            let copy_len = max_payload.len().min(buf.len());
-            buf[..copy_len].copy_from_slice(&max_payload[..copy_len]);
-            Ok(copy_len)
+        let result = medium.serialize(reply_context, &mut buffer, |encoder| {
+            encoder
+                .write_all(&max_payload)
+                .map_err(|_| MctpPacketError::SerializeError("encode error"))
         });
 
         assert!(result.is_ok());
         let serialized = result.unwrap();
         assert_eq!(serialized.len(), 260); // Should use exactly all available space
 
-        // Test with buffer one byte too small for maximum payload
+        // Test with buffer one byte too small for maximum payload.
+        // The encoder will hit BufferFull when trying to write the
+        // 255th payload byte (only 254 fit after header reservation),
+        // so this serialize call now returns an error rather than
+        // silently truncating.
         let mut small_buffer = [0u8; 259]; // One byte short for max payload
-        let result_small = medium.serialize(reply_context, &mut small_buffer, |buf| {
-            // Try to write max payload but buffer is too small
-            let copy_len = max_payload.len().min(buf.len());
-            buf[..copy_len].copy_from_slice(&max_payload[..copy_len]);
-            Ok(copy_len)
+        let result_small = medium.serialize(reply_context, &mut small_buffer, |encoder| {
+            encoder
+                .write_all(&max_payload)
+                .map_err(|_| MctpPacketError::SerializeError("encode error"))
         });
 
-        // Should still work but with truncated payload (254 bytes payload + 4 header + 1 PEC = 259)
-        assert!(result_small.is_ok());
-        let serialized_small = result_small.unwrap();
-        assert_eq!(serialized_small.len(), 259); // Uses all available space
+        assert_eq!(
+            result_small.err().unwrap(),
+            MctpPacketError::SerializeError("encode error")
+        );
     }
 }

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -73,20 +73,16 @@ impl<'buf, M: MctpMedium> SerializePacketState<'buf, M> {
                 .map_err(MctpPacketError::SerializeError)?;
 
                 // write the transport header and message body via the
-                // medium-supplied encoder. For PassthroughEncoding each
-                // `write` consumes 1 wire byte; for stuffing encodings each
-                // call may emit >1.
+                // medium-supplied encoder.
                 let map_encode_err = |e: EncodeError| match e {
                     EncodeError::BufferFull => {
                         MctpPacketError::SerializeError("encoding: buffer full")
                     }
                 };
-                for byte in transport_header.to_be_bytes() {
-                    encoder.write(byte).map_err(map_encode_err)?;
-                }
-                for &byte in body {
-                    encoder.write(byte).map_err(map_encode_err)?;
-                }
+                encoder
+                    .write_all(&transport_header.to_be_bytes())
+                    .map_err(map_encode_err)?;
+                encoder.write_all(body).map_err(map_encode_err)?;
                 Ok(())
             },
         );

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -1,6 +1,6 @@
 use crate::{
     MctpPacketError,
-    buffer_encoding::{BufferEncoding, EncodeError},
+    buffer_encoding::{EncodeError, EncodingEncoder},
     error::MctpPacketResult,
     mctp_packet_context::MctpReplyContext,
     mctp_transport_header::MctpTransportHeader,
@@ -29,8 +29,11 @@ impl<'buf, M: MctpMedium> SerializePacketState<'buf, M> {
         let packet = self.medium.serialize(
             self.reply_context.medium_context,
             self.assembly_buffer,
-            |buffer: &mut [u8]| {
-                let max_packet_size = self.medium.max_message_body_size().min(buffer.len());
+            |encoder: &mut EncodingEncoder<'_, M::Encoding>| {
+                let max_packet_size = self
+                    .medium
+                    .max_message_body_size()
+                    .min(encoder.remaining_wire());
                 if max_packet_size < TRANSPORT_HEADER_SIZE {
                     return Err(MctpPacketError::SerializeError(
                         "assembly buffer too small for mctp transport header",
@@ -69,32 +72,22 @@ impl<'buf, M: MctpMedium> SerializePacketState<'buf, M> {
                 .try_into()
                 .map_err(MctpPacketError::SerializeError)?;
 
-                // write the transport header and message body via the medium's
-                // BufferEncoding. For PassthroughEncoding each call writes 1
-                // wire byte; for stuffing encodings each call may emit >1.
-                let mut wire_cursor = 0;
+                // write the transport header and message body via the
+                // medium-supplied encoder. For PassthroughEncoding each
+                // `write` consumes 1 wire byte; for stuffing encodings each
+                // call may emit >1.
                 let map_encode_err = |e: EncodeError| match e {
                     EncodeError::BufferFull => {
                         MctpPacketError::SerializeError("encoding: buffer full")
                     }
                 };
                 for byte in transport_header.to_be_bytes() {
-                    let n = <M::Encoding as BufferEncoding>::write_byte(
-                        &mut buffer[wire_cursor..],
-                        byte,
-                    )
-                    .map_err(map_encode_err)?;
-                    wire_cursor += n;
+                    encoder.write(byte).map_err(map_encode_err)?;
                 }
                 for &byte in body {
-                    let n = <M::Encoding as BufferEncoding>::write_byte(
-                        &mut buffer[wire_cursor..],
-                        byte,
-                    )
-                    .map_err(map_encode_err)?;
-                    wire_cursor += n;
+                    encoder.write(byte).map_err(map_encode_err)?;
                 }
-                Ok(wire_cursor)
+                Ok(())
             },
         );
 

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -1,6 +1,10 @@
 use crate::{
-    MctpPacketError, error::MctpPacketResult, mctp_packet_context::MctpReplyContext,
-    mctp_transport_header::MctpTransportHeader, medium::MctpMedium,
+    MctpPacketError,
+    buffer_encoding::{BufferEncoding, EncodeError},
+    error::MctpPacketResult,
+    mctp_packet_context::MctpReplyContext,
+    mctp_transport_header::MctpTransportHeader,
+    medium::MctpMedium,
 };
 
 #[derive(Debug, PartialEq, Eq)]
@@ -65,14 +69,32 @@ impl<'buf, M: MctpMedium> SerializePacketState<'buf, M> {
                 .try_into()
                 .map_err(MctpPacketError::SerializeError)?;
 
-                // write the transport header and message body
-                let mut cursor = 0;
-                buffer[cursor..cursor + TRANSPORT_HEADER_SIZE]
-                    .copy_from_slice(&transport_header.to_be_bytes());
-                cursor += TRANSPORT_HEADER_SIZE;
-                // message body is the rest of the buffer, up to the packet size
-                buffer[cursor..cursor + body.len()].copy_from_slice(body);
-                Ok(cursor + body.len())
+                // write the transport header and message body via the medium's
+                // BufferEncoding. For PassthroughEncoding each call writes 1
+                // wire byte; for stuffing encodings each call may emit >1.
+                let mut wire_cursor = 0;
+                let map_encode_err = |e: EncodeError| match e {
+                    EncodeError::BufferFull => {
+                        MctpPacketError::SerializeError("encoding: buffer full")
+                    }
+                };
+                for byte in transport_header.to_be_bytes() {
+                    let n = <M::Encoding as BufferEncoding>::write_byte(
+                        &mut buffer[wire_cursor..],
+                        byte,
+                    )
+                    .map_err(map_encode_err)?;
+                    wire_cursor += n;
+                }
+                for &byte in body {
+                    let n = <M::Encoding as BufferEncoding>::write_byte(
+                        &mut buffer[wire_cursor..],
+                        byte,
+                    )
+                    .map_err(map_encode_err)?;
+                    wire_cursor += n;
+                }
+                Ok(wire_cursor)
             },
         );
 

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -1,5 +1,6 @@
 use crate::{
     MctpPacketError,
+    buffer_encoding::{EncodingDecoder, EncodingEncoder, PassthroughEncoding},
     error::MctpPacketResult,
     medium::{MctpMedium, MctpMediumFrame},
 };
@@ -36,12 +37,12 @@ impl MctpMedium for TestMedium {
     type Frame = TestMediumFrame;
     type Error = &'static str;
     type ReplyContext = ();
-    type Encoding = crate::buffer_encoding::PassthroughEncoding;
+    type Encoding = PassthroughEncoding;
 
     fn deserialize<'buf>(
         &self,
         packet: &'buf [u8],
-    ) -> MctpPacketResult<(Self::Frame, &'buf [u8]), Self> {
+    ) -> MctpPacketResult<(Self::Frame, EncodingDecoder<'buf, Self::Encoding>), Self> {
         let packet_len = packet.len();
 
         // check that header / trailer is present and correct
@@ -55,8 +56,8 @@ impl MctpMedium for TestMedium {
             return Err(MctpPacketError::MediumError("trailer mismatch"));
         }
 
-        let packet = &packet[self.header.len()..packet_len - self.trailer.len()];
-        Ok((TestMediumFrame(packet_len), packet))
+        let inner = &packet[self.header.len()..packet_len - self.trailer.len()];
+        Ok((TestMediumFrame(packet_len), EncodingDecoder::new(inner)))
     }
     fn max_message_body_size(&self) -> usize {
         self.mtu
@@ -68,7 +69,7 @@ impl MctpMedium for TestMedium {
         message_writer: F,
     ) -> MctpPacketResult<&'buf [u8], Self>
     where
-        F: for<'a> FnOnce(&'a mut [u8]) -> MctpPacketResult<usize, Self>,
+        F: for<'a> FnOnce(&mut EncodingEncoder<'a, Self::Encoding>) -> MctpPacketResult<(), Self>,
     {
         let header_len = self.header.len();
         let trailer_len = self.trailer.len();
@@ -86,8 +87,16 @@ impl MctpMedium for TestMedium {
         let max_message_size = max_packet_size - header_len - trailer_len;
 
         buffer[0..header_len].copy_from_slice(self.header);
-        let size = message_writer(&mut buffer[header_len..header_len + max_message_size])?;
-        let len = header_len + size;
+
+        let body_wire_len: usize;
+        {
+            let body_buf = &mut buffer[header_len..header_len + max_message_size];
+            let mut encoder = EncodingEncoder::<Self::Encoding>::new(body_buf);
+            message_writer(&mut encoder)?;
+            body_wire_len = encoder.wire_position();
+        }
+
+        let len = header_len + body_wire_len;
         buffer[len..len + trailer_len].copy_from_slice(self.trailer);
         Ok(&buffer[..len + trailer_len])
     }

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -88,13 +88,12 @@ impl MctpMedium for TestMedium {
 
         buffer[0..header_len].copy_from_slice(self.header);
 
-        let body_wire_len: usize;
-        {
+        let body_wire_len = {
             let body_buf = &mut buffer[header_len..header_len + max_message_size];
             let mut encoder = EncodingEncoder::<Self::Encoding>::new(body_buf);
             message_writer(&mut encoder)?;
-            body_wire_len = encoder.wire_position();
-        }
+            encoder.wire_position()
+        };
 
         let len = header_len + body_wire_len;
         buffer[len..len + trailer_len].copy_from_slice(self.trailer);

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -36,6 +36,7 @@ impl MctpMedium for TestMedium {
     type Frame = TestMediumFrame;
     type Error = &'static str;
     type ReplyContext = ();
+    type Encoding = crate::buffer_encoding::PassthroughEncoding;
 
     fn deserialize<'buf>(
         &self,


### PR DESCRIPTION
Stateless byte-stuffing transform abstraction in `dymk/mctp-rs` (`BufferEncoding`) plus two generic concrete cursor wrappers (`EncodingDecoder<'buf, E>` / `EncodingEncoder<'buf, E>`) that encapsulate the buffer behind the encoding. Future media (DSP0253 serial in #12, etc.) plug in their own `BufferEncoding` impl without further changes to the core deserialize/serialize pipeline.

**This is the foundation PR. The first consumer (`MctpSerialMedium`) is stacked in #12.**

## What's delivered

| Symbol | Where | What |
|---|---|---|
| `BufferEncoding` trait | `src/buffer_encoding.rs` (new) | Stateless: two associated fns `write_byte(wire_buf, byte) -> Result<usize, EncodeError>` and `read_byte(wire_buf) -> Result<(u8, usize), DecodeError>`. NO `self`, NO state — caller manages all cursors. ALWAYS-ON (NOT feature-gated). |
| `PassthroughEncoding` ZST | `src/buffer_encoding.rs` | No-op transform: `write_byte` writes 1 byte, `read_byte` returns `(wire_buf[0], 1)`. Both existing media (`SmbusEspiMedium`, `TestMedium`) set `type Encoding = PassthroughEncoding;`. |
| `EncodingDecoder<'buf, E>` / `EncodingEncoder<'buf, E>` | `src/buffer_encoding.rs` | Generic concrete cursor structs wrapping the stateless trait + buffer + wire offset. `MctpMedium::deserialize` returns `(Frame, EncodingDecoder<'buf, Self::Encoding>)`; `MctpMedium::serialize`'s closure takes `&mut EncodingEncoder<'_, Self::Encoding>`. **Helpers (`parse_transport_header`, body copy, `SerializePacketState::next`'s closure) take `&mut Decoder/Encoder` and physically cannot bypass the encoding by slicing the underlying buffer directly.** |
| `type Encoding: BufferEncoding;` on `MctpMedium` | `src/medium/mod.rs` | One associated type. NO factory methods, NO GATs (trait stays stateless). Stable Rust, no new language features. |

## Why this shape

The "stateless trait + generic cursor wrapper" design (vs. a per-medium iterator trait, which was the original sketch) lands in just **9 atomic commits** while:

1. **Preserving zero behavioral change** for existing runtime paths — 49 pre-existing lib tests + 3 doctests pass identically to baseline `3d941ba`. `PassthroughEncoding` makes per-byte access observably equivalent (1 wire byte ↔ 1 decoded byte, no transform).
2. **Making encoding bypass impossible** at the helper level — helpers receive `&mut EncodingDecoder/Encoder`, not raw slices. Bypass would require explicit unsafe or new API surface.
3. **Avoiding GATs and lifetime-polymorphic associated types** — the trait is parameter-less, the cursor structs carry the buffer lifetime.
4. **Adding zero new dependencies** — `Cargo.toml` `[dependencies]` and `[features]` sections unchanged. The `crc 3.4` dep + `serial = ["dep:crc"]` feature land in #12 alongside the first non-Passthrough impl.

## Commit shortlog (9 atomic commits, in execution order)

```
39cd212  feat(buffer-encoding): add stateless BufferEncoding trait + PassthroughEncoding
ffa16d6  feat(buffer-encoding): wire BufferEncoding through MctpPacketContext
a245c08  fix(buffer-encoding): drop misleading wire-vs-decoded length prechecks
ed62bc4  feat(buffer-encoding): introduce EncodingDecoder/Encoder cursor wrappers
d30c84f  refactor(buffer-encoding): drop unused decoded_count field
532c90c  refactor(buffer-encoding): drop unused public API surface
9289728  refactor(buffer-encoding): use expression blocks and write_all in serialize impls
3bfd456  refactor(buffer-encoding): consolidate test helpers and decode error mapping
90ec404  docs(buffer-encoding): trim docstrings and clarify unreachable variant
```

The first 4 commits build the abstraction; the last 5 are simplification-focused refactors driven by an internal code review (dropping `decoded_count` after observing it was effectively dead, dropping unused public accessors, consolidating test helpers, etc.). Each commit individually passes the cargo-husky 17-combo `cargo hack --feature-powerset` clippy + test matrix with `-D warnings`.

## Verification

- **49 pre-existing lib tests + 3 doctests pass** identically to pre-Phase-25 baseline (`3d941ba`); 4 new inline tests added during simplification refactors (53 lib + 3 doc total at HEAD).
- `git diff 3d941ba..90ec404 -- Cargo.toml` is empty — no dependency or feature changes.
- 17-combo cargo-husky pre-commit matrix GREEN at every commit boundary.

## Stacked PRs

- **This PR (foundation):** dymk/mctp-rs#13 *(this one)* — `BufferEncoding` trait + cursor wrappers
- **Next (consumer):** dymk/mctp-rs#12 — `MctpSerialMedium` (DSP0253 byte-stuffed serial), stacked on this branch


