### PR TITLE
phase-25.5: MctpSerialMedium (DSP0253 byte-stuffed serial)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,12 @@ edition = "2024"
 default = []
 espi = ["dep:espi-device"]
 defmt = ["dep:defmt", "embedded-batteries/defmt"]
+serial = ["dep:crc"]
 
 [dependencies]
 espi-device = { git = "https://github.com/OpenDevicePartnership/haf-ec-service", optional = true }
 bit-register = { git = "https://github.com/OpenDevicePartnership/odp-utilities", package = "bit-register" }
+crc = { version = "3.4", default-features = false, optional = true }
 num_enum = { version = "0.7.4", default-features = false }
 smbus-pec = "1.0.1"
 thiserror = { version = "2.0.16", default-features = false }

--- a/src/buffer_encoding.rs
+++ b/src/buffer_encoding.rs
@@ -52,6 +52,12 @@ pub trait BufferEncoding {
     /// index 0. Returns `(decoded_byte, wire_bytes_consumed)`. The
     /// caller advances their read cursor by `wire_bytes_consumed`.
     fn read_byte(wire_buf: &[u8]) -> Result<(u8, usize), DecodeError>;
+
+    /// Wire-byte footprint of `decoded` under this encoding. Must equal
+    /// the sum of `write_byte(_, b)` lengths for each `b` in `decoded`.
+    /// NO default impl: every encoding declares its sizing rule
+    /// explicitly.
+    fn wire_size_of(decoded: &[u8]) -> usize;
 }
 
 /// No-op encoding: wire bytes ARE payload bytes. Used by media that do
@@ -76,6 +82,10 @@ impl BufferEncoding for PassthroughEncoding {
             Some(&byte) => Ok((byte, 1)),
             None => Err(DecodeError::PrematureEnd),
         }
+    }
+
+    fn wire_size_of(decoded: &[u8]) -> usize {
+        decoded.len()
     }
 }
 
@@ -225,5 +235,13 @@ mod tests {
             assert_eq!(encoder.write(0x55).unwrap_err(), EncodeError::BufferFull);
         }
         assert_eq!(buf, [0x11, 0x22, 0x33, 0x44]);
+    }
+
+    #[test]
+    fn passthrough_wire_size_of_returns_input_len() {
+        assert_eq!(PassthroughEncoding::wire_size_of(&[]), 0);
+        assert_eq!(PassthroughEncoding::wire_size_of(&[0xAB]), 1);
+        let buf = [0u8; 64];
+        assert_eq!(PassthroughEncoding::wire_size_of(&buf), 64);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,6 +183,10 @@ pub use error::{MctpPacketError, MctpPacketResult};
 pub use mctp_message_tag::MctpMessageTag;
 pub use mctp_packet_context::{MctpPacketContext, MctpReplyContext};
 pub use mctp_sequence_number::MctpSequenceNumber;
+#[cfg(feature = "serial")]
+pub use medium::serial::{
+    CONST_MTU, EC_EID, MctpSerialMedium, MctpSerialMediumFrame, SP_EID, SerialEncoding,
+};
 pub use medium::*;
 pub use message_type::*;
 

--- a/src/medium/mod.rs
+++ b/src/medium/mod.rs
@@ -6,6 +6,9 @@ use crate::{
 pub mod smbus_espi;
 mod util;
 
+#[cfg(feature = "serial")]
+pub mod serial;
+
 pub trait MctpMedium: Sized {
     /// the medium specific header and trailer for the packet
     type Frame: MctpMediumFrame<Self>;

--- a/src/medium/serial.rs
+++ b/src/medium/serial.rs
@@ -2,12 +2,16 @@
 //!
 //! Two-layer split:
 //!   - [`SerialEncoding`]: stateless byte-stuffing (0x7E, 0x7D escape pair).
-//!   - `MctpSerialMedium` (added in Task 4): framing (revision byte, byte_count, body, FCS-16,
-//!     end-flag).
+//!   - [`MctpSerialMedium`]: framing (revision byte, byte_count, body, FCS-16, end-flag).
 //!
 //! Both layers are gated behind the `serial` cargo feature.
 
-use crate::buffer_encoding::{BufferEncoding, DecodeError, EncodeError};
+use crate::{
+    MctpPacketError,
+    buffer_encoding::{BufferEncoding, DecodeError, EncodeError, EncodingDecoder, EncodingEncoder},
+    error::MctpPacketResult,
+    medium::{MctpMedium, MctpMediumFrame},
+};
 
 /// DSP0253 byte-stuffing transform. Stateless ZST.
 ///
@@ -73,6 +77,236 @@ impl BufferEncoding for SerialEncoding {
             .iter()
             .map(|&b| if b == 0x7E || b == 0x7D { 2 } else { 1 })
             .sum()
+    }
+}
+
+/// SP MCTP endpoint id per CONTEXT D-D-06.
+pub const SP_EID: crate::endpoint_id::EndpointId = crate::endpoint_id::EndpointId::Id(0x08);
+/// EC MCTP endpoint id per CONTEXT D-D-06.
+pub const EC_EID: crate::endpoint_id::EndpointId = crate::endpoint_id::EndpointId::Id(0x0A);
+/// Maximum DSP0253 packet body size (DECODED bytes, before stuffing).
+pub const CONST_MTU: usize = 251;
+
+const SERIAL_REVISION: u8 = 0x01;
+const END_FLAG: u8 = 0x7E;
+/// Header bytes: revision + byte_count (decoded body byte count).
+const HEADER_LEN: usize = 2;
+/// Worst-case trailer wire bytes: 2 stuffed FCS bytes (each may
+/// expand 1 -> 2) + 1 end-flag.
+const MAX_TRAILER_WIRE: usize = 5;
+
+// CRC-16/X-25 per DSP0253 §8 (poly 0x1021, init 0xFFFF, refin/refout,
+// xorout 0xFFFF). Algorithm catalog entry locked in CONTEXT D-D-02.
+// FCS bytes on the wire are MSB-first per DSP0253 §5.2 (overrides
+// RFC1662's LSB-first PPP convention).
+const FCS_ALGO: crc::Crc<u16> = crc::Crc::<u16>::new(&crc::CRC_16_IBM_SDLC);
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct MctpSerialMediumFrame {
+    pub revision: u8,
+    /// DECODED body byte count per DSP0253 §6.2 (NOT the wire byte
+    /// count). Cap = `CONST_MTU` = 251; max u8 = 255, fits comfortably.
+    pub byte_count: u8,
+    pub fcs: u16,
+}
+
+impl MctpMediumFrame<MctpSerialMedium> for MctpSerialMediumFrame {
+    fn packet_size(&self) -> usize {
+        // packet_size is the DECODED body byte count — the contract
+        // used by `MctpPacketContext::deserialize_packet`, which then
+        // subtracts 4 for the transport header.
+        self.byte_count as usize
+    }
+
+    fn reply_context(&self) {}
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct MctpSerialMedium;
+
+impl MctpMedium for MctpSerialMedium {
+    type Frame = MctpSerialMediumFrame;
+    type Error = &'static str;
+    type ReplyContext = ();
+    type Encoding = SerialEncoding;
+
+    fn max_message_body_size(&self) -> usize {
+        CONST_MTU
+    }
+
+    fn deserialize<'buf>(
+        &self,
+        packet: &'buf [u8],
+    ) -> MctpPacketResult<(Self::Frame, EncodingDecoder<'buf, Self::Encoding>), Self> {
+        // Minimum frame: 2 header + 0 body + 2 FCS (unstuffed) + 1 end-flag = 5 bytes.
+        if packet.len() < HEADER_LEN + 3 {
+            return Err(MctpPacketError::MediumError(
+                "packet too short for serial frame",
+            ));
+        }
+        let revision = packet[0];
+        if revision != SERIAL_REVISION {
+            return Err(MctpPacketError::MediumError("unsupported serial revision"));
+        }
+        let byte_count = packet[1];
+        if (byte_count as usize) > CONST_MTU {
+            return Err(MctpPacketError::MediumError("byte_count exceeds MTU"));
+        }
+
+        // Single forward walk: un-stuff body bytes (count must equal
+        // `byte_count`), un-stuff 2 FCS bytes, expect end-flag, compare
+        // CRC.
+        let body_wire_start = HEADER_LEN;
+        let mut decoded = [0u8; CONST_MTU];
+        let mut decoded_len = 0usize;
+        let mut wire_pos = 0usize; // offset from body_wire_start
+
+        while decoded_len < byte_count as usize {
+            let (b, n) =
+                SerialEncoding::read_byte(&packet[body_wire_start + wire_pos..]).map_err(|e| {
+                    match e {
+                        DecodeError::PrematureEnd => {
+                            MctpPacketError::MediumError("premature end in body")
+                        }
+                        DecodeError::InvalidEscape => {
+                            MctpPacketError::MediumError("invalid escape in body")
+                        }
+                    }
+                })?;
+            if b == END_FLAG {
+                // Bare 0x7E inside the body region is a protocol error
+                // (MEDIUM-05).
+                return Err(MctpPacketError::MediumError("unexpected 0x7E in body"));
+            }
+            decoded[decoded_len] = b;
+            decoded_len += 1;
+            wire_pos += n;
+        }
+        let body_wire_end = body_wire_start + wire_pos;
+
+        // Un-stuff 2 FCS bytes (DSP0253 §7.1 stuffing applies to FCS).
+        let (fcs_msb, n_msb) = SerialEncoding::read_byte(&packet[body_wire_end..])
+            .map_err(|_| MctpPacketError::MediumError("invalid escape in fcs"))?;
+        let (fcs_lsb, n_lsb) = SerialEncoding::read_byte(&packet[body_wire_end + n_msb..])
+            .map_err(|_| MctpPacketError::MediumError("invalid escape in fcs"))?;
+        let trailer_pos = body_wire_end + n_msb + n_lsb;
+
+        if trailer_pos >= packet.len() || packet[trailer_pos] != END_FLAG {
+            return Err(MctpPacketError::MediumError("missing end flag"));
+        }
+        if trailer_pos + 1 != packet.len() {
+            return Err(MctpPacketError::MediumError(
+                "trailing bytes after end flag",
+            ));
+        }
+
+        // FCS-16/X-25 over un-stuffed (revision || byte_count || decoded body).
+        let mut digest = FCS_ALGO.digest();
+        digest.update(&[revision, byte_count]);
+        digest.update(&decoded[..decoded_len]);
+        let computed_fcs = digest.finalize();
+        // DSP0253 §5.2: MSB first on wire.
+        let wire_fcs = u16::from_be_bytes([fcs_msb, fcs_lsb]);
+        if wire_fcs != computed_fcs {
+            return Err(MctpPacketError::MediumError("fcs mismatch"));
+        }
+
+        Ok((
+            MctpSerialMediumFrame {
+                revision,
+                byte_count,
+                fcs: wire_fcs,
+            },
+            EncodingDecoder::<Self::Encoding>::new(&packet[body_wire_start..body_wire_end]),
+        ))
+    }
+
+    fn serialize<'buf, F>(
+        &self,
+        _reply_context: Self::ReplyContext,
+        buffer: &'buf mut [u8],
+        message_writer: F,
+    ) -> MctpPacketResult<&'buf [u8], Self>
+    where
+        F: for<'a> FnOnce(&mut EncodingEncoder<'a, Self::Encoding>) -> MctpPacketResult<(), Self>,
+    {
+        if buffer.len() < HEADER_LEN + MAX_TRAILER_WIRE {
+            return Err(MctpPacketError::MediumError(
+                "buffer too small for serial frame",
+            ));
+        }
+        let buffer_len = buffer.len();
+
+        // Run closure over body region (reserve worst-case 5-byte
+        // trailer). The encoder stuffs body bytes via
+        // `SerialEncoding::write_byte` automatically.
+        let body_wire_len = {
+            let body_buf = &mut buffer[HEADER_LEN..buffer_len - MAX_TRAILER_WIRE];
+            let mut encoder = EncodingEncoder::<Self::Encoding>::new(body_buf);
+            message_writer(&mut encoder)?;
+            encoder.wire_position()
+        };
+
+        // Re-decode body to recover DECODED bytes + decoded count for
+        // `byte_count` and FCS. CONTEXT D-B-02 acknowledges the
+        // double-walk; ~250 bytes max, no_std, cheap.
+        let mut decoded = [0u8; CONST_MTU];
+        let mut decoded_len = 0usize;
+        let mut wire_pos = 0usize;
+        while wire_pos < body_wire_len {
+            let (b, n) = SerialEncoding::read_byte(
+                &buffer[HEADER_LEN + wire_pos..HEADER_LEN + body_wire_len],
+            )
+            .map_err(|_| MctpPacketError::MediumError("internal: failed to re-decode body"))?;
+            if decoded_len >= CONST_MTU {
+                return Err(MctpPacketError::MediumError("body exceeds MTU"));
+            }
+            decoded[decoded_len] = b;
+            decoded_len += 1;
+            wire_pos += n;
+        }
+        // Should not fire — `EncodingEncoder::write` returns
+        // `BufferFull` long before decoded_len could exceed 251.
+        if decoded_len > u8::MAX as usize {
+            return Err(MctpPacketError::MediumError(
+                "body exceeds byte_count u8 cap",
+            ));
+        }
+        let byte_count = decoded_len as u8;
+
+        // FCS-16/X-25 over un-stuffed (revision || byte_count || decoded body).
+        let mut digest = FCS_ALGO.digest();
+        digest.update(&[SERIAL_REVISION, byte_count]);
+        digest.update(&decoded[..decoded_len]);
+        let fcs = digest.finalize();
+        // DSP0253 §5.2: MSB first on wire.
+        let [fcs_msb, fcs_lsb] = fcs.to_be_bytes();
+
+        // Header: revision + byte_count emitted directly (NOT stuffed),
+        // matching `SmbusEspiMedium`'s header pattern. See PLAN
+        // <behavior> note for the conformance caveat when byte_count
+        // happens to equal 0x7E or 0x7D — round-trips cleanly through
+        // this implementation's deserialize.
+        buffer[0] = SERIAL_REVISION;
+        buffer[1] = byte_count;
+
+        // Stuff and write FCS bytes via SerialEncoding (DSP0253 §7.1 +
+        // CONTEXT D-B-02 — deserialize un-stuffs FCS, so serialize
+        // must stuff).
+        let fcs_start = HEADER_LEN + body_wire_len;
+        let n_msb = SerialEncoding::write_byte(&mut buffer[fcs_start..], fcs_msb)
+            .map_err(|_| MctpPacketError::MediumError("internal: failed to encode fcs"))?;
+        let n_lsb = SerialEncoding::write_byte(&mut buffer[fcs_start + n_msb..], fcs_lsb)
+            .map_err(|_| MctpPacketError::MediumError("internal: failed to encode fcs"))?;
+        let end_pos = fcs_start + n_msb + n_lsb;
+
+        // End-flag is written directly (flags are NOT stuffed by
+        // definition).
+        buffer[end_pos] = END_FLAG;
+
+        Ok(&buffer[..end_pos + 1])
     }
 }
 

--- a/src/medium/serial.rs
+++ b/src/medium/serial.rs
@@ -672,6 +672,15 @@ mod medium_tests {
     }
 
     #[test]
+    fn public_api_smoke() {
+        let _: crate::MctpSerialMedium = crate::MctpSerialMedium;
+        let _: crate::SerialEncoding = crate::SerialEncoding;
+        assert_eq!(crate::CONST_MTU, 251);
+        assert_eq!(crate::SP_EID, crate::EndpointId::Id(0x08));
+        assert_eq!(crate::EC_EID, crate::EndpointId::Id(0x0A));
+    }
+
+    #[test]
     fn packetize_with_stuffing_respects_mtu() {
         // 251-byte payload of all 0x7E. Each byte stuffs to 2 wire
         // bytes (0x7D 0x5E), so encoded body footprint per packet is

--- a/src/medium/serial.rs
+++ b/src/medium/serial.rs
@@ -1,0 +1,206 @@
+//! DSP0253 byte-stuffed serial medium for MCTP.
+//!
+//! Two-layer split:
+//!   - [`SerialEncoding`]: stateless byte-stuffing (0x7E, 0x7D escape pair).
+//!   - `MctpSerialMedium` (added in Task 4): framing (revision byte, byte_count, body, FCS-16,
+//!     end-flag).
+//!
+//! Both layers are gated behind the `serial` cargo feature.
+
+use crate::buffer_encoding::{BufferEncoding, DecodeError, EncodeError};
+
+/// DSP0253 byte-stuffing transform. Stateless ZST.
+///
+/// Encode: `0x7E -> [0x7D, 0x5E]`, `0x7D -> [0x7D, 0x5D]`, any other
+/// byte -> `[b]`.
+/// Decode: `0x7D 0x5E -> 0x7E`, `0x7D 0x5D -> 0x7D`, `0x7D <other>` ->
+/// `InvalidEscape`.
+///
+/// Raw `0x7E` in the wire stream is NOT rejected here — that's a
+/// framing concern owned by `MctpSerialMedium::deserialize`, which
+/// checks the body region for stray flags.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct SerialEncoding;
+
+impl BufferEncoding for SerialEncoding {
+    fn write_byte(wire_buf: &mut [u8], byte: u8) -> Result<usize, EncodeError> {
+        match byte {
+            0x7E => {
+                if wire_buf.len() < 2 {
+                    return Err(EncodeError::BufferFull);
+                }
+                wire_buf[0] = 0x7D;
+                wire_buf[1] = 0x5E;
+                Ok(2)
+            }
+            0x7D => {
+                if wire_buf.len() < 2 {
+                    return Err(EncodeError::BufferFull);
+                }
+                wire_buf[0] = 0x7D;
+                wire_buf[1] = 0x5D;
+                Ok(2)
+            }
+            b => match wire_buf.first_mut() {
+                Some(slot) => {
+                    *slot = b;
+                    Ok(1)
+                }
+                None => Err(EncodeError::BufferFull),
+            },
+        }
+    }
+
+    fn read_byte(wire_buf: &[u8]) -> Result<(u8, usize), DecodeError> {
+        match wire_buf.first().copied() {
+            None => Err(DecodeError::PrematureEnd),
+            Some(0x7D) => match wire_buf.get(1).copied() {
+                None => Err(DecodeError::PrematureEnd),
+                Some(0x5E) => Ok((0x7E, 2)),
+                Some(0x5D) => Ok((0x7D, 2)),
+                Some(_) => Err(DecodeError::InvalidEscape),
+            },
+            // Raw 0x7E falls through here as a 1-byte read; the framing
+            // layer (`MctpSerialMedium::deserialize`) rejects bare
+            // 0x7E inside the body region.
+            Some(b) => Ok((b, 1)),
+        }
+    }
+
+    fn wire_size_of(decoded: &[u8]) -> usize {
+        decoded
+            .iter()
+            .map(|&b| if b == 0x7E || b == 0x7D { 2 } else { 1 })
+            .sum()
+    }
+}
+
+#[cfg(test)]
+mod encoding_tests {
+    use super::*;
+    use crate::buffer_encoding::EncodingDecoder;
+
+    #[test]
+    fn write_byte_stuffs_7e() {
+        let mut buf = [0u8; 4];
+        let n = SerialEncoding::write_byte(&mut buf, 0x7E).unwrap();
+        assert_eq!(n, 2);
+        assert_eq!(&buf[..2], &[0x7D, 0x5E]);
+    }
+
+    #[test]
+    fn write_byte_stuffs_7d() {
+        let mut buf = [0u8; 4];
+        let n = SerialEncoding::write_byte(&mut buf, 0x7D).unwrap();
+        assert_eq!(n, 2);
+        assert_eq!(&buf[..2], &[0x7D, 0x5D]);
+    }
+
+    #[test]
+    fn write_byte_passthrough_plain() {
+        let mut buf = [0u8; 1];
+        let n = SerialEncoding::write_byte(&mut buf, 0x41).unwrap();
+        assert_eq!(n, 1);
+        assert_eq!(buf, [0x41]);
+    }
+
+    #[test]
+    fn write_byte_full_buffer_plain() {
+        let mut buf = [];
+        assert_eq!(
+            SerialEncoding::write_byte(&mut buf, 0x41).unwrap_err(),
+            EncodeError::BufferFull
+        );
+    }
+
+    #[test]
+    fn write_byte_full_buffer_escape() {
+        let mut buf = [0u8; 1];
+        assert_eq!(
+            SerialEncoding::write_byte(&mut buf, 0x7E).unwrap_err(),
+            EncodeError::BufferFull
+        );
+    }
+
+    #[test]
+    fn read_byte_unstuffs_7e() {
+        assert_eq!(SerialEncoding::read_byte(&[0x7D, 0x5E]).unwrap(), (0x7E, 2));
+    }
+
+    #[test]
+    fn read_byte_unstuffs_7d() {
+        assert_eq!(SerialEncoding::read_byte(&[0x7D, 0x5D]).unwrap(), (0x7D, 2));
+    }
+
+    #[test]
+    fn read_byte_passthrough_plain() {
+        assert_eq!(SerialEncoding::read_byte(&[0x41]).unwrap(), (0x41, 1));
+    }
+
+    #[test]
+    fn read_byte_raw_7e_passes_through() {
+        // Raw 0x7E is NOT rejected at the encoding layer — framing is
+        // the framing layer's concern.
+        assert_eq!(SerialEncoding::read_byte(&[0x7E]).unwrap(), (0x7E, 1));
+    }
+
+    #[test]
+    fn read_byte_premature_end_empty() {
+        assert_eq!(
+            SerialEncoding::read_byte(&[]).unwrap_err(),
+            DecodeError::PrematureEnd
+        );
+    }
+
+    #[test]
+    fn read_byte_premature_end_after_escape() {
+        assert_eq!(
+            SerialEncoding::read_byte(&[0x7D]).unwrap_err(),
+            DecodeError::PrematureEnd
+        );
+    }
+
+    #[test]
+    fn read_byte_invalid_escape() {
+        assert_eq!(
+            SerialEncoding::read_byte(&[0x7D, 0xAA]).unwrap_err(),
+            DecodeError::InvalidEscape
+        );
+    }
+
+    #[test]
+    fn wire_size_of_mixed() {
+        assert_eq!(
+            SerialEncoding::wire_size_of(&[0x41, 0x7E, 0x42, 0x7D, 0x43]),
+            7
+        );
+    }
+
+    #[test]
+    fn wire_size_of_empty() {
+        assert_eq!(SerialEncoding::wire_size_of(&[]), 0);
+    }
+
+    #[test]
+    fn roundtrip_all_byte_values() {
+        // 256-byte payload of every byte value, encoded into a 512-byte
+        // wire buffer (worst case is 2x expansion if every byte stuffs;
+        // actual expansion here is 256 + 2 = 258 wire bytes).
+        let mut decoded = [0u8; 256];
+        for (i, slot) in decoded.iter_mut().enumerate() {
+            *slot = i as u8;
+        }
+        let mut wire = [0u8; 512];
+        let mut wpos = 0usize;
+        for &b in &decoded {
+            wpos += SerialEncoding::write_byte(&mut wire[wpos..], b).unwrap();
+        }
+        assert_eq!(wpos, SerialEncoding::wire_size_of(&decoded));
+        let mut dec = EncodingDecoder::<SerialEncoding>::new(&wire[..wpos]);
+        for &expected in &decoded {
+            assert_eq!(dec.read().unwrap(), expected);
+        }
+        assert_eq!(dec.read().unwrap_err(), DecodeError::PrematureEnd);
+    }
+}

--- a/src/medium/serial.rs
+++ b/src/medium/serial.rs
@@ -175,9 +175,11 @@ impl MctpMedium for MctpSerialMedium {
                         }
                     }
                 })?;
-            if b == END_FLAG {
-                // Bare 0x7E inside the body region is a protocol error
-                // (MEDIUM-05).
+            if b == END_FLAG && n == 1 {
+                // Bare (unstuffed) 0x7E inside the body region is a
+                // protocol error (MEDIUM-05). A decoded 0x7E whose wire
+                // representation was the stuffed pair `0x7D 0x5E`
+                // (n==2) is a legitimate payload byte and is kept.
                 return Err(MctpPacketError::MediumError("unexpected 0x7E in body"));
             }
             decoded[decoded_len] = b;
@@ -436,5 +438,236 @@ mod encoding_tests {
             assert_eq!(dec.read().unwrap(), expected);
         }
         assert_eq!(dec.read().unwrap_err(), DecodeError::PrematureEnd);
+    }
+}
+
+#[cfg(test)]
+mod fixtures {
+    //! Hand-authored DSP0253 serial frame fixtures (golden vectors).
+    //!
+    //! Layout per fixture (no leading flag — this implementation omits
+    //! the open `0x7E` per CONTEXT D-D-01; upstream UART layer supplies
+    //! it in Phase 27):
+    //!
+    //!   `[REVISION=0x01, byte_count, ...stuffed body..., ...stuffed FCS-MSB..., ...stuffed
+    //! FCS-LSB..., 0x7E]`
+    //!
+    //! - Header bytes (REVISION, byte_count) are NOT stuffed (matches production serialize).
+    //! - Body bytes are stuffed per `SerialEncoding`.
+    //! - FCS-16/X-25 computed over un-stuffed `[REVISION, byte_count, ...decoded body...]`, emitted
+    //!   MSB-first on wire (DSP0253 §5.2), each FCS byte then stuffed if equal to 0x7E or 0x7D.
+    //! - Trailing `0x7E` is the end-flag (not stuffed by definition).
+
+    pub(crate) const FIXTURE_BASIC_RX: &[u8] =
+        &[0x01, 0x04, 0xAA, 0xBB, 0xCC, 0xDD, 0x6D, 0xA1, 0x7E];
+
+    pub(crate) const FIXTURE_PAYLOAD_CONTAINS_7E: &[u8] =
+        &[0x01, 0x03, 0xAA, 0x7D, 0x5E, 0xCC, 0xFB, 0xE7, 0x7E];
+
+    pub(crate) const FIXTURE_PAYLOAD_CONTAINS_7D: &[u8] =
+        &[0x01, 0x03, 0xAA, 0x7D, 0x5D, 0xCC, 0xD1, 0x8F, 0x7E];
+
+    pub(crate) const FIXTURE_PAYLOAD_CONTAINS_BOTH: &[u8] =
+        &[0x01, 0x03, 0x7D, 0x5E, 0x7D, 0x5D, 0x42, 0x50, 0x97, 0x7E];
+
+    /// 251-byte body `(0..251)` decoded; wire = 258 bytes after stuffing
+    /// the lone 0x7D (idx 125) and 0x7E (idx 126) inside the body.
+    pub(crate) const FIXTURE_MAX_MTU_FRAME: &[u8] = &[
+        0x01, 0xFB, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C,
+        0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B,
+        0x1C, 0x1D, 0x1E, 0x1F, 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2A,
+        0x2B, 0x2C, 0x2D, 0x2E, 0x2F, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39,
+        0x3A, 0x3B, 0x3C, 0x3D, 0x3E, 0x3F, 0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48,
+        0x49, 0x4A, 0x4B, 0x4C, 0x4D, 0x4E, 0x4F, 0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57,
+        0x58, 0x59, 0x5A, 0x5B, 0x5C, 0x5D, 0x5E, 0x5F, 0x60, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66,
+        0x67, 0x68, 0x69, 0x6A, 0x6B, 0x6C, 0x6D, 0x6E, 0x6F, 0x70, 0x71, 0x72, 0x73, 0x74, 0x75,
+        0x76, 0x77, 0x78, 0x79, 0x7A, 0x7B, 0x7C, 0x7D, 0x5D, 0x7D, 0x5E, 0x7F, 0x80, 0x81, 0x82,
+        0x83, 0x84, 0x85, 0x86, 0x87, 0x88, 0x89, 0x8A, 0x8B, 0x8C, 0x8D, 0x8E, 0x8F, 0x90, 0x91,
+        0x92, 0x93, 0x94, 0x95, 0x96, 0x97, 0x98, 0x99, 0x9A, 0x9B, 0x9C, 0x9D, 0x9E, 0x9F, 0xA0,
+        0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7, 0xA8, 0xA9, 0xAA, 0xAB, 0xAC, 0xAD, 0xAE, 0xAF,
+        0xB0, 0xB1, 0xB2, 0xB3, 0xB4, 0xB5, 0xB6, 0xB7, 0xB8, 0xB9, 0xBA, 0xBB, 0xBC, 0xBD, 0xBE,
+        0xBF, 0xC0, 0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0xC7, 0xC8, 0xC9, 0xCA, 0xCB, 0xCC, 0xCD,
+        0xCE, 0xCF, 0xD0, 0xD1, 0xD2, 0xD3, 0xD4, 0xD5, 0xD6, 0xD7, 0xD8, 0xD9, 0xDA, 0xDB, 0xDC,
+        0xDD, 0xDE, 0xDF, 0xE0, 0xE1, 0xE2, 0xE3, 0xE4, 0xE5, 0xE6, 0xE7, 0xE8, 0xE9, 0xEA, 0xEB,
+        0xEC, 0xED, 0xEE, 0xEF, 0xF0, 0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA,
+        0xF6, 0x07, 0x7E,
+    ];
+
+    pub(crate) const FIXTURE_EMPTY_PAYLOAD: &[u8] = &[0x01, 0x00, 0x16, 0x9F, 0x7E];
+
+    pub(crate) const FIXTURE_FCS_VALID: &[u8] = &[0x01, 0x03, 0x10, 0x20, 0x30, 0x76, 0xDB, 0x7E];
+
+    /// Same body as FCS_VALID but FCS-MSB byte XOR 0xFF (0x76 -> 0x89).
+    pub(crate) const FIXTURE_FCS_INVALID: &[u8] = &[0x01, 0x03, 0x10, 0x20, 0x30, 0x89, 0xDB, 0x7E];
+
+    /// byte_count=2 claims 2 decoded bytes; first body wire byte is
+    /// `0x7D 0xAA` (escape followed by non-`{0x5E,0x5D}`) -> rejected
+    /// as "invalid escape in body" before reaching FCS.
+    pub(crate) const FIXTURE_INVALID_ESCAPE: &[u8] = &[0x01, 0x02, 0x7D, 0xAA, 0x00, 0x00, 0x7E];
+
+    /// byte_count=3, body wire region is `[0xAA, 0x7E, 0xCC]` — the
+    /// raw 0x7E inside the body region is rejected before FCS.
+    pub(crate) const FIXTURE_PREMATURE_END_FLAG: &[u8] =
+        &[0x01, 0x03, 0xAA, 0x7E, 0xCC, 0x00, 0x00, 0x7E];
+}
+
+#[cfg(test)]
+mod medium_tests {
+    use super::{fixtures::*, *};
+
+    fn drain_decoder(mut dec: EncodingDecoder<'_, SerialEncoding>) -> ([u8; CONST_MTU], usize) {
+        let mut out = [0u8; CONST_MTU];
+        let mut n = 0;
+        while let Ok(b) = dec.read() {
+            out[n] = b;
+            n += 1;
+        }
+        (out, n)
+    }
+
+    #[test]
+    fn decode_basic_rx_succeeds() {
+        let (frame, dec) = MctpSerialMedium.deserialize(FIXTURE_BASIC_RX).unwrap();
+        assert_eq!(frame.revision, 0x01);
+        assert_eq!(frame.byte_count, 4);
+        assert_eq!(frame.fcs, 0x6DA1);
+        let (decoded, n) = drain_decoder(dec);
+        assert_eq!(&decoded[..n], &[0xAA, 0xBB, 0xCC, 0xDD]);
+    }
+
+    #[test]
+    fn decode_payload_contains_7e() {
+        let (frame, dec) = MctpSerialMedium
+            .deserialize(FIXTURE_PAYLOAD_CONTAINS_7E)
+            .unwrap();
+        assert_eq!(frame.byte_count, 3);
+        let (decoded, n) = drain_decoder(dec);
+        assert_eq!(&decoded[..n], &[0xAA, 0x7E, 0xCC]);
+    }
+
+    #[test]
+    fn decode_payload_contains_7d() {
+        let (frame, dec) = MctpSerialMedium
+            .deserialize(FIXTURE_PAYLOAD_CONTAINS_7D)
+            .unwrap();
+        assert_eq!(frame.byte_count, 3);
+        let (decoded, n) = drain_decoder(dec);
+        assert_eq!(&decoded[..n], &[0xAA, 0x7D, 0xCC]);
+    }
+
+    #[test]
+    fn decode_payload_contains_both() {
+        let (frame, dec) = MctpSerialMedium
+            .deserialize(FIXTURE_PAYLOAD_CONTAINS_BOTH)
+            .unwrap();
+        assert_eq!(frame.byte_count, 3);
+        let (decoded, n) = drain_decoder(dec);
+        assert_eq!(&decoded[..n], &[0x7E, 0x7D, 0x42]);
+    }
+
+    #[test]
+    fn decode_max_mtu_frame() {
+        let (frame, dec) = MctpSerialMedium.deserialize(FIXTURE_MAX_MTU_FRAME).unwrap();
+        assert_eq!(frame.byte_count as usize, CONST_MTU);
+        let (decoded, n) = drain_decoder(dec);
+        assert_eq!(n, CONST_MTU);
+        for (i, &b) in decoded[..n].iter().enumerate() {
+            assert_eq!(b, i as u8, "mismatch at idx {i}");
+        }
+    }
+
+    #[test]
+    fn decode_empty_payload() {
+        let (frame, dec) = MctpSerialMedium.deserialize(FIXTURE_EMPTY_PAYLOAD).unwrap();
+        assert_eq!(frame.byte_count, 0);
+        let (_, n) = drain_decoder(dec);
+        assert_eq!(n, 0);
+    }
+
+    #[test]
+    fn decode_fcs_valid() {
+        assert!(MctpSerialMedium.deserialize(FIXTURE_FCS_VALID).is_ok());
+    }
+
+    #[test]
+    fn decode_fcs_invalid_rejects() {
+        match MctpSerialMedium.deserialize(FIXTURE_FCS_INVALID) {
+            Err(crate::MctpPacketError::MediumError("fcs mismatch")) => {}
+            other => panic!(
+                "expected MediumError(\"fcs mismatch\"), got {:?}",
+                other.err()
+            ),
+        }
+    }
+
+    #[test]
+    fn decode_invalid_escape_rejects() {
+        match MctpSerialMedium.deserialize(FIXTURE_INVALID_ESCAPE) {
+            Err(crate::MctpPacketError::MediumError("invalid escape in body")) => {}
+            other => panic!(
+                "expected MediumError(\"invalid escape in body\"), got {:?}",
+                other.err()
+            ),
+        }
+    }
+
+    #[test]
+    fn decode_premature_end_flag_rejects() {
+        match MctpSerialMedium.deserialize(FIXTURE_PREMATURE_END_FLAG) {
+            Err(crate::MctpPacketError::MediumError("unexpected 0x7E in body")) => {}
+            other => panic!(
+                "expected MediumError(\"unexpected 0x7E in body\"), got {:?}",
+                other.err()
+            ),
+        }
+    }
+
+    fn fixture_roundtrip(wire: &[u8]) {
+        let m = MctpSerialMedium;
+        let (_frame, dec) = m.deserialize(wire).unwrap();
+        let (decoded, n) = drain_decoder(dec);
+        let mut out = [0u8; 1024];
+        let serialized = m
+            .serialize((), &mut out, |e| {
+                e.write_all(&decoded[..n])
+                    .map_err(|_| MctpPacketError::MediumError("write failed"))
+            })
+            .unwrap();
+        assert_eq!(serialized, wire);
+    }
+
+    #[test]
+    fn fixture_roundtrip_basic_rx() {
+        fixture_roundtrip(FIXTURE_BASIC_RX);
+    }
+
+    #[test]
+    fn fixture_roundtrip_payload_contains_7e() {
+        fixture_roundtrip(FIXTURE_PAYLOAD_CONTAINS_7E);
+    }
+
+    #[test]
+    fn fixture_roundtrip_payload_contains_7d() {
+        fixture_roundtrip(FIXTURE_PAYLOAD_CONTAINS_7D);
+    }
+
+    #[test]
+    fn fixture_roundtrip_payload_contains_both() {
+        fixture_roundtrip(FIXTURE_PAYLOAD_CONTAINS_BOTH);
+    }
+
+    #[test]
+    fn fixture_roundtrip_max_mtu_frame() {
+        fixture_roundtrip(FIXTURE_MAX_MTU_FRAME);
+    }
+
+    #[test]
+    fn fixture_roundtrip_empty_payload() {
+        fixture_roundtrip(FIXTURE_EMPTY_PAYLOAD);
+    }
+
+    #[test]
+    fn fixture_roundtrip_fcs_valid() {
+        fixture_roundtrip(FIXTURE_FCS_VALID);
     }
 }

--- a/src/medium/serial.rs
+++ b/src/medium/serial.rs
@@ -670,4 +670,81 @@ mod medium_tests {
     fn fixture_roundtrip_fcs_valid() {
         fixture_roundtrip(FIXTURE_FCS_VALID);
     }
+
+    #[test]
+    fn packetize_with_stuffing_respects_mtu() {
+        // 251-byte payload of all 0x7E. Each byte stuffs to 2 wire
+        // bytes (0x7D 0x5E), so encoded body footprint per packet is
+        // 2x decoded length. The packet body MTU is 251 wire bytes;
+        // each MCTP packet also carries a 4-byte transport header
+        // which itself is `wire_size_of`-measured. Expect the message
+        // to split across multiple packets and no body region to
+        // exceed CONST_MTU wire bytes.
+        use crate::{
+            endpoint_id::EndpointId, mctp_message_tag::MctpMessageTag,
+            mctp_packet_context::MctpReplyContext, mctp_sequence_number::MctpSequenceNumber,
+            serialize::SerializePacketState,
+        };
+
+        let payload = [0x7E_u8; 251];
+        let mut assembly = [0u8; 1024];
+        let medium = MctpSerialMedium;
+        let reply_context = MctpReplyContext::<MctpSerialMedium> {
+            destination_endpoint_id: EndpointId::Id(0x0A),
+            source_endpoint_id: EndpointId::Id(0x08),
+            packet_sequence_number: MctpSequenceNumber::new(0),
+            message_tag: MctpMessageTag::default(),
+            medium_context: (),
+        };
+        let mut state = SerializePacketState {
+            medium: &medium,
+            reply_context,
+            current_packet_num: 0,
+            serialized_message_header: false,
+            message_buffer: &payload[..],
+            assembly_buffer: &mut assembly[..],
+        };
+
+        let mut total_decoded_body = 0usize;
+        let mut packet_count = 0usize;
+        loop {
+            // We cannot iterate `state.next()` more than once because
+            // `next` mutably borrows the assembly buffer for each
+            // returned slice. Take one packet, process it, then break.
+            let pkt = match state.next() {
+                Some(Ok(pkt)) => {
+                    let mut tmp = [0u8; 1024];
+                    tmp[..pkt.len()].copy_from_slice(pkt);
+                    (tmp, pkt.len())
+                }
+                Some(Err(e)) => panic!("serialize error: {e:?}"),
+                None => break,
+            };
+            packet_count += 1;
+            // Deserialize the packet to recover the wire body length
+            // and the decoded body byte count.
+            let (frame, dec) = medium.deserialize(&pkt.0[..pkt.1]).unwrap();
+            // Decoded body byte count INCLUDES the 4 transport-header
+            // bytes — subtract to get the actual payload bytes.
+            assert!(frame.byte_count as usize >= 4);
+            let payload_decoded = frame.byte_count as usize - 4;
+            total_decoded_body += payload_decoded;
+            // Wire body region (between header and FCS) MUST be <=
+            // CONST_MTU under MEDIUM-08 chunk-sizing.
+            let _ = dec; // decoder discard
+            let wire_body_len = pkt.1 - 2 /* hdr */ - 1 /* end-flag */;
+            // Subtract the (possibly stuffed) FCS bytes — they are 2
+            // FCS bytes but each may stuff to 2 wire bytes. Worst case
+            // 4 bytes; lower bound on body wire = wire_body_len - 4.
+            assert!(
+                wire_body_len <= CONST_MTU + 4,
+                "packet {packet_count} body exceeds MTU + worst-case FCS: {wire_body_len}"
+            );
+        }
+        assert!(
+            packet_count >= 2,
+            "expected multi-packet split, got {packet_count}"
+        );
+        assert_eq!(total_decoded_body, payload.len());
+    }
 }

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -1,6 +1,6 @@
 use crate::{
     MctpPacketError,
-    buffer_encoding::{EncodeError, EncodingEncoder},
+    buffer_encoding::{BufferEncoding, EncodeError, EncodingEncoder},
     error::MctpPacketResult,
     mctp_packet_context::MctpReplyContext,
     mctp_transport_header::MctpTransportHeader,
@@ -30,18 +30,55 @@ impl<'buf, M: MctpMedium> SerializePacketState<'buf, M> {
             self.reply_context.medium_context,
             self.assembly_buffer,
             |encoder: &mut EncodingEncoder<'_, M::Encoding>| {
-                let max_packet_size = self
+                let max_wire = self
                     .medium
                     .max_message_body_size()
                     .min(encoder.remaining_wire());
-                if max_packet_size < TRANSPORT_HEADER_SIZE {
+
+                // Build the transport header first (with end_of_message
+                // tentatively 0) so we can measure its wire footprint
+                // under the medium's encoding before chunking the body.
+                let start_of_message = if self.current_packet_num == 0 { 1 } else { 0 };
+                let packet_sequence_number = self.reply_context.packet_sequence_number.inc();
+                let mut transport_header_value: u32 = MctpTransportHeader {
+                    reserved: 0,
+                    header_version: 1,
+                    start_of_message,
+                    end_of_message: 0,
+                    packet_sequence_number,
+                    tag_owner: 0,
+                    message_tag: self.reply_context.message_tag,
+                    source_endpoint_id: self.reply_context.destination_endpoint_id,
+                    destination_endpoint_id: self.reply_context.source_endpoint_id,
+                }
+                .try_into()
+                .map_err(MctpPacketError::SerializeError)?;
+                let mut header_bytes = transport_header_value.to_be_bytes();
+                let header_wire_cost = M::Encoding::wire_size_of(&header_bytes);
+                if header_wire_cost > max_wire {
                     return Err(MctpPacketError::SerializeError(
                         "assembly buffer too small for mctp transport header",
                     ));
                 }
 
-                let message_size =
-                    (max_packet_size - TRANSPORT_HEADER_SIZE).min(self.message_buffer.len());
+                // Walk decoded body bytes one at a time, accumulating
+                // their per-byte wire footprint via
+                // `M::Encoding::wire_size_of`. Stop when adding the
+                // next byte would exceed the wire budget. Correct for
+                // both passthrough and stuffing encodings (both shipped
+                // encodings are byte-additive — `wire_size_of(a ++ b)
+                // == wire_size_of(a) + wire_size_of(b)`).
+                let body_wire_budget = max_wire - header_wire_cost;
+                let mut consumed_wire = 0usize;
+                let mut message_size = 0usize;
+                for &b in self.message_buffer.iter() {
+                    let cost = M::Encoding::wire_size_of(&[b]);
+                    if consumed_wire + cost > body_wire_budget {
+                        break;
+                    }
+                    consumed_wire += cost;
+                    message_size += 1;
+                }
 
                 // if there is no room for any of the body, and the body is not empty,
                 // then return an error, otherwise we infinate loop sending packets with headers and
@@ -55,22 +92,34 @@ impl<'buf, M: MctpMedium> SerializePacketState<'buf, M> {
                 let body = &self.message_buffer[..message_size];
                 self.message_buffer = &self.message_buffer[message_size..];
 
-                let start_of_message = if self.current_packet_num == 0 { 1 } else { 0 };
+                // Now that we know whether this is the final chunk,
+                // rebuild the transport header if `end_of_message`
+                // flips to 1. Re-measure the wire cost — none of the
+                // EOM-bit bytes hit 0x7E or 0x7D under either shipped
+                // encoding in practice, but do not assume.
                 let end_of_message = if self.message_buffer.is_empty() { 1 } else { 0 };
-                let packet_sequence_number = self.reply_context.packet_sequence_number.inc();
-                let transport_header: u32 = MctpTransportHeader {
-                    reserved: 0,
-                    header_version: 1,
-                    start_of_message,
-                    end_of_message,
-                    packet_sequence_number,
-                    tag_owner: 0,
-                    message_tag: self.reply_context.message_tag,
-                    source_endpoint_id: self.reply_context.destination_endpoint_id,
-                    destination_endpoint_id: self.reply_context.source_endpoint_id,
+                if end_of_message == 1 {
+                    transport_header_value = MctpTransportHeader {
+                        reserved: 0,
+                        header_version: 1,
+                        start_of_message,
+                        end_of_message,
+                        packet_sequence_number,
+                        tag_owner: 0,
+                        message_tag: self.reply_context.message_tag,
+                        source_endpoint_id: self.reply_context.destination_endpoint_id,
+                        destination_endpoint_id: self.reply_context.source_endpoint_id,
+                    }
+                    .try_into()
+                    .map_err(MctpPacketError::SerializeError)?;
+                    header_bytes = transport_header_value.to_be_bytes();
+                    let rebuilt_header_wire_cost = M::Encoding::wire_size_of(&header_bytes);
+                    if rebuilt_header_wire_cost + consumed_wire > max_wire {
+                        return Err(MctpPacketError::SerializeError(
+                            "assembly buffer too small after EOM bit set",
+                        ));
+                    }
                 }
-                .try_into()
-                .map_err(MctpPacketError::SerializeError)?;
 
                 // write the transport header and message body via the
                 // medium-supplied encoder.
@@ -79,9 +128,7 @@ impl<'buf, M: MctpMedium> SerializePacketState<'buf, M> {
                         MctpPacketError::SerializeError("encoding: buffer full")
                     }
                 };
-                encoder
-                    .write_all(&transport_header.to_be_bytes())
-                    .map_err(map_encode_err)?;
+                encoder.write_all(&header_bytes).map_err(map_encode_err)?;
                 encoder.write_all(body).map_err(map_encode_err)?;
                 Ok(())
             },


### PR DESCRIPTION
DSP0253-conformant `MctpSerialMedium` (byte-stuffed serial wire) shipped on top of Phase 25's `BufferEncoding` / `MctpMedium` foundation, plus the `wire_size_of` trait extension that fixes `SerializePacketState::next` chunk-sizing for stuffing encodings.

**Stacked on:** `main` (post-Phase-25 merge — Phase 25 (#13) merged into main; this PR is now standalone with 7 atomic commits).

## What's delivered (behind `serial = ["dep:crc"]` cargo feature)

| Symbol | Where | What |
|---|---|---|
| `BufferEncoding::wire_size_of(&[u8]) -> usize` | `src/buffer_encoding.rs` | Stateless third trait fn; `PassthroughEncoding` returns `decoded.len()`, `SerialEncoding` walks +2 per `0x7E`/`0x7D` byte and +1 per other byte |
| `SerialEncoding` ZST | `src/medium/serial.rs` | DSP0253 §7.1 byte-stuffing rules: `0x7E → 0x7D 0x5E`, `0x7D → 0x7D 0x5D`, strict accept-list on decode (returns `DecodeError::InvalidEscape` on any other `0x7D <byte>`) |
| `MctpSerialMedium` ZST | `src/medium/serial.rs` | `impl MctpMedium with type Encoding = SerialEncoding`. Wire frame: `[revision=0x01, byte_count, body, FCS_MSB, FCS_LSB, 0x7E]` (open `0x7E` flag supplied by upstream UART byte-stream layer, planned for Phase 27 in `embedded-services::uart-service`) |
| `MctpSerialMediumFrame` | `src/medium/serial.rs` | `{ revision: u8, byte_count: u8, fcs: u16 }`. **`byte_count` is the DECODED body byte count** per DSP0253 §6.2 — wire-byte count of stuffed payloads can exceed 255 (worst-case 502 wire bytes for a 251-decoded-byte payload of all `0x7E`), so wire-byte semantics couldn't fit in u8 |
| `pub const SP_EID = 0x08; EC_EID = 0x0A; CONST_MTU = 251;` | `src/medium/serial.rs` | Endpoint IDs and decoded-body MTU |
| 10 inline `pub(crate) const FIXTURE_*` golden-vector arrays | `src/medium/serial.rs` (`mod tests`) | Hand-authored wire bytes (FCS via offline Python CRC-16/X-25 generator). 7 successful + 3 rejection fixtures |
| `SerializePacketState::next` precise chunk-sizing | `src/serialize.rs` | Replaces `min(remaining_wire())` with a body-prefix scan via `M::Encoding::wire_size_of` so stuffing encodings pack correctly |

## Design highlights

- **FCS algorithm:** CRC-16/X-25 (`crc::Crc::<u16>::new(&crc::CRC_16_IBM_SDLC)`) over un-stuffed `revision || byte_count || body`, MSB-first on wire (DSP0253 §5.2 — overrides RFC1662's LSB-first PPP convention; cross-checked against libmctp `serial.c` `tlr->fcs_msb = fcs >> 8` and mctp-estack)
- **FCS bytes are themselves byte-stuffed** if they happen to contain `0x7E` or `0x7D` (DSP0253 §7.1 / RFC1662 §4.2 — stuffing applies to "all bytes between framing flags")
- **Upfront FCS validation in `deserialize`** — single-pass walk through the wire frame validates FCS before returning the decoder to higher layers (matches `SmbusEspiMedium`'s upfront-PEC pattern; helpers never see corrupted frames)
- **No async, no allocator on runtime path, no new heavy deps** — only `crc 3.4` (Table<1> backend, ~512B `.rodata` for u16 polynomial)
- **`MctpPacketContext::deserialize_packet(&[u8])` signature unchanged** — Phase 25's byte-at-a-time streaming via `EncodingDecoder` removed the original "in-place mutation" need

## Verification

- **88 unit tests + 3 doc-tests pass** with `--features serial` (15 encoding + 17 medium + 56 pre-existing). The 7 `fixture_roundtrip_*` tests pin the wire format byte-for-byte: each runs `serialize(deserialize(FIXTURE_X)) == FIXTURE_X` so any drift in FCS algorithm, byte order, header emission, or stuffing rules would fail immediately.
- **9-combo (actually 17-combo) clippy matrix GREEN** at every commit boundary — cargo-husky pre-commit hook ran the full `cargo hack --feature-powerset clippy --all-targets ... -D warnings` plus `cargo hack --feature-powerset test` for `{default, defmt, espi, serial}`.

## Notable executor catch (one plan-bug, surfaced and fixed in this branch)

The original PLAN.md had a logic bug in `MctpSerialMedium::deserialize`'s body walk — it checked `if b == END_FLAG` against the **decoded** byte, which would have rejected legitimately-stuffed `0x7E` payload bytes (`0x7D 0x5E` decodes to `0x7E` — that's a valid payload byte, not an end-flag). Fixed to `if b == END_FLAG && n == 1` so only RAW (un-stuffed, `n == 1`) `0x7E` bytes are rejected. The `FIXTURE_PAYLOAD_CONTAINS_7E` vs `FIXTURE_PREMATURE_END_FLAG` test pair surfaced this immediately in commit `20df5a4`.

## Commit shortlog (7 atomic commits, in order)

```
78a4f06  feat(serial): expose `serial` module under `cfg(feature = "serial")`
f3180e8  fix(serialize): size packet chunks via `Encoding::wire_size_of`
20df5a4  test(serial): inline golden fixtures plus decoder/serialize roundtrip tests
3ef0a1f  feat(serial): add `MctpSerialMedium` with FCS-16 framing
e8cce7c  feat(serial): add `SerialEncoding` byte-stuffing impl
ab38f59  feat(buffer-encoding): extend `BufferEncoding` with `wire_size_of`
23e0e44  feat(serial): add `serial` cargo feature and crc 3.4 dependency
```



